### PR TITLE
remove auth from some endpoints

### DIFF
--- a/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
@@ -25,6 +25,8 @@ class ActiniaInterface(object):
         self.host = config.HOST
         self.port = config.PORT
         self.base_url = "%(host)s:%(port)s/latest" % {"host": self.host, "port": self.port}
+        self.auth = (config.USER, config.PASSWORD)
+        self.user = config.USER
 
     def set_auth(self, user: str, password: str):
         self.auth = (user, password)

--- a/src/openeo_grass_gis_driver/capabilities.py
+++ b/src/openeo_grass_gis_driver/capabilities.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
+from flask_restful import Resource
 from flask import make_response, jsonify
-
-from openeo_grass_gis_driver.authentication import ResourceBase
 
 __license__ = "Apache License, Version 2.0"
 __author__ = "Sören Gebbert"
@@ -94,7 +93,7 @@ CAPABILITIES = {
 }
 
 
-class Capabilities(ResourceBase):
+class Capabilities(Resource):
 
     def get(self, ):
         return make_response(jsonify(CAPABILITIES), 200)
@@ -103,7 +102,7 @@ class Capabilities(ResourceBase):
 SERVICE_TYPES = {}
 
 
-class ServiceTypes(ResourceBase):
+class ServiceTypes(Resource):
 
     def get(self, ):
         return make_response(jsonify(SERVICE_TYPES), 200)

--- a/src/openeo_grass_gis_driver/collection_information.py
+++ b/src/openeo_grass_gis_driver/collection_information.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+from flask_restful import Resource
 from flask import make_response, jsonify, request
 from openeo_grass_gis_driver.actinia_processing.actinia_interface import ActiniaInterface
 from openeo_grass_gis_driver.collection_schemas import CollectionInformation, Extent, EoLinks
-from openeo_grass_gis_driver.authentication import ResourceBase
 from osgeo import osr, ogr
 
 __license__ = "Apache License, Version 2.0"
@@ -106,11 +106,10 @@ def coorindate_transform_extent_to_EPSG_4326(crs: str, extent: Extent):
     return extent
 
 
-class CollectionInformationResource(ResourceBase):
+class CollectionInformationResource(Resource):
 
     def __init__(self):
         self.iface = ActiniaInterface()
-        self.iface.set_auth(request.authorization.username, request.authorization.password)
 
     def get(self, name):
 

--- a/src/openeo_grass_gis_driver/collections.py
+++ b/src/openeo_grass_gis_driver/collections.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
+from flask_restful import Resource
 from flask import make_response, jsonify, request
 
 from .actinia_processing.actinia_interface import ActiniaInterface
 from openeo_grass_gis_driver.actinia_processing.config import Config
 from openeo_grass_gis_driver.collection_schemas import Collection, CollectionEntry
-from openeo_grass_gis_driver.authentication import ResourceBase
 
 __license__ = "Apache License, Version 2.0"
 __author__ = "Sören Gebbert"
@@ -13,11 +13,10 @@ __maintainer__ = "Soeren Gebbert"
 __email__ = "soerengebbert@googlemail.com"
 
 
-class Collections(ResourceBase):
+class Collections(Resource):
 
     def __init__(self):
         self.iface = ActiniaInterface()
-        self.iface.set_auth(request.authorization.username, request.authorization.password)
 
     def get(self):
 

--- a/src/openeo_grass_gis_driver/jobs.py
+++ b/src/openeo_grass_gis_driver/jobs.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from uuid import uuid4
 from datetime import datetime
+from flask_restful import Resource
 from flask import make_response, jsonify, request
 from openeo_grass_gis_driver.process_graph_db import GraphDB
 from openeo_grass_gis_driver.job_db import JobDB
@@ -34,7 +35,7 @@ OUTPUT_FORMATS = {
 }
 
 
-class OutputFormats(ResourceBase):
+class OutputFormats(Resource):
 
     def get(self, ):
         return make_response(jsonify(OUTPUT_FORMATS), 200)

--- a/src/openeo_grass_gis_driver/processes.py
+++ b/src/openeo_grass_gis_driver/processes.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
+from flask_restful import Resource
 from flask import make_response, jsonify
 from openeo_grass_gis_driver.actinia_processing.base import PROCESS_DESCRIPTION_DICT
-from openeo_grass_gis_driver.authentication import ResourceBase
 
 __license__ = "Apache License, Version 2.0"
 __author__ = "Sören Gebbert"
@@ -10,7 +10,7 @@ __maintainer__ = "Soeren Gebbert"
 __email__ = "soerengebbert@googlemail.com"
 
 
-class Processes(ResourceBase):
+class Processes(Resource):
 
     def get(self):
 


### PR DESCRIPTION
The basic auth is now removed from some endpoints:
https://github.com/Open-EO/openeo-grassgis-driver/issues/18

- for /collections and /collections/{name} the authentication is taken from the config