### PR TITLE
WIP: Well known

### DIFF
--- a/src/openeo_grass_gis_driver/endpoints.py
+++ b/src/openeo_grass_gis_driver/endpoints.py
@@ -12,6 +12,7 @@ from openeo_grass_gis_driver.preview import Preview
 from openeo_grass_gis_driver.jobs_job_id_results import JobsJobIdResults
 from openeo_grass_gis_driver.process_graphs import ProcessGraphs
 from openeo_grass_gis_driver.process_graphs_id import ProcessGraphId
+from openeo_grass_gis_driver.well_known import WellKnown
 
 __license__ = "Apache License, Version 2.0"
 __author__ = "Sören Gebbert"
@@ -42,3 +43,4 @@ def create_endpoints():
     flask_api.add_resource(JobsJobId, '/jobs/<string:job_id>')
     flask_api.add_resource(JobsJobIdResults, '/jobs/<string:job_id>/results')
 
+    flask_api.add_resource(WellKnown, '/.well-known/openeo')

--- a/src/openeo_grass_gis_driver/well_known.py
+++ b/src/openeo_grass_gis_driver/well_known.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from flask_restful import Resource
+from flask import make_response, jsonify, request
+
+
+__license__ = "Apache License, Version 2.0"
+__author__ = "Carmen Tawalika"
+__copyright__ = "2018-present mundialis GmbH & Co. KG"
+
+
+class WellKnown(Resource):
+
+    def __init__(self):
+        Resource.__init__(self)
+
+    def get(self):
+
+        host_url = request.host_url
+
+        versions = dict()
+        versions['0.3.1'] = host_url + "api/v0.3/"
+        versions['0.4.0'] = host_url + "api/v0.4/"
+
+        resp = dict()
+        resp['versions'] = versions
+
+        return make_response(jsonify(resp), 200)


### PR DESCRIPTION
As demanded from v0.4.0, we need to support the /.well-known/openeo endpoint showing current available versions (https://github.com/Open-EO/openeo-api/releases/tag/0.4.0). This PR adds this endpoint.
I made it WIP because I would like to discuss if this really belongs into the code because it itself doesn't know, where it is deployed. Else, I would not know how else to support this. Any ideas? It would look like this: 

```
{
  "versions": {
    "0.3.1": "http://127.0.0.1:5000/api/v0.3/", 
    "0.4.0": "http://127.0.0.1:5000/api/v0.4/"
  }
}
```
