### PR TITLE
re-enable auth fix tests

### DIFF
--- a/src/openeo_grass_gis_driver/authentication.py
+++ b/src/openeo_grass_gis_driver/authentication.py
@@ -77,8 +77,7 @@ def requires_authorization(f):
 
 class ResourceBase(Resource):
     decorators = []
-    # TODO: fixme
-    # decorators.append(requires_authorization)
+    decorators.append(requires_authorization)
 
     def __init__(self):
         Resource.__init__(self)

--- a/src/openeo_grass_gis_driver/test_base.py
+++ b/src/openeo_grass_gis_driver/test_base.py
@@ -31,7 +31,7 @@ class TestBase(unittest.TestCase):
         self.auth.add('Authorization', 'Basic ' + encodeAuth)
         response = self.app.get('/credentials/basic', headers=self.auth)
         resp_data = json.loads(response.data.decode())
-        self.auth.set('Authorization', 'Bearer ' + resp_data['access_token'])
+        self.auth.set('Authorization', 'Bearer basic//' + resp_data['access_token'])
 
     def wait_until_finished(self, response, http_status=200, status="finished"):
         """Poll the status of a resource and assert its finished HTTP status


### PR DESCRIPTION
This PR re-adds the decorator to enable authentication + fixes the tests.

With this PR, all tests pass:
```
================== 53 passed, 1 warning in 109.52s (0:01:49) ===================

```