### PR TITLE
register actinia modules on startup

### DIFF
--- a/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
@@ -4,10 +4,9 @@ from openeo_grass_gis_driver.actinia_processing.config import Config as ActiniaC
 import requests
 
 __license__ = "Apache License, Version 2.0"
-__author__ = "Sören Gebbert"
-__copyright__ = "Copyright 2018, Sören Gebbert, mundialis"
-__maintainer__ = "Soeren Gebbert"
-__email__ = "soerengebbert@googlemail.com"
+__author__ = "Sören Gebbert, Carmen Tawalika"
+__copyright__ = "Copyright 2018-2021, Sören Gebbert, mundialis"
+__maintainer__ = "mundialis"
 
 
 class ActiniaInterface(object):
@@ -222,11 +221,11 @@ class ActiniaInterface(object):
 
     def get_resource(self, url: str) -> Tuple[int, dict]:
         """Get a resource from actinia pointed to by url, e.g. a GeoTIFF
-        
+
             !!!THIS IS DANGEROUS!!!
             it will load the whole resource into RAM
         """
-        
+
         r = requests.get(url=url, auth=self.auth)
 
         #import pdb; pdb.set_trace()
@@ -300,3 +299,25 @@ class ActiniaInterface(object):
         url = "%(base)s/locations/%(location)s/processing_async_export" % {"base": self.base_url,
                                                                                "location": location}
         return self._send_post_request(url=url, process_chain=process_chain)
+
+    def list_modules(self) -> Tuple[int, dict]:
+        url = "%(base)s/modules" % {"base": self.base_url}
+        r = requests.get(url=url, auth=self.auth)
+        data = r.text
+
+        if r.status_code == 200:
+            ret = r.json()
+            data = ret["processes"]
+
+        return r.status_code, data
+
+    def list_module(self, module) -> Tuple[int, dict]:
+        url = "%(base)s/modules/%(module)s" % {"base": self.base_url, "module": module}
+        r = requests.get(url=url, auth=self.auth)
+        data = r.text
+
+        if r.status_code == 200:
+            ret = r.json()
+            data = ret
+
+        return r.status_code, data

--- a/src/openeo_grass_gis_driver/actinia_processing/base.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/base.py
@@ -7,6 +7,7 @@ from openeo_grass_gis_driver.actinia_processing.actinia_interface import Actinia
 
 from openeo_grass_gis_driver.models.process_graph_schemas import ProcessGraph
 
+ACTINIA_PROCESS_DESCRIPTION_DICT = {}
 PROCESS_DESCRIPTION_DICT = {}
 PROCESS_DICT = {}
 
@@ -47,7 +48,7 @@ class DataObject:
     def from_string(name: str):
 
         location, mapset, datatype, layer_name = ActiniaInterface.layer_def_to_components(name)
-        
+
         if datatype is None:
             raise Exception(f"Invalid collection id <{name}>")
 

--- a/src/openeo_grass_gis_driver/main.py
+++ b/src/openeo_grass_gis_driver/main.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 from openeo_grass_gis_driver.app import flask_app
 from openeo_grass_gis_driver.endpoints import create_endpoints
+from openeo_grass_gis_driver.register_processes import register_processes
 
 
 __license__ = "Apache License, Version 2.0"
-__author__ = "Sören Gebbert"
-__copyright__ = "Copyright 2018, Sören Gebbert, mundialis"
-__maintainer__ = "Soeren Gebbert"
-__email__ = "soerengebbert@googlemail.com"
+__author__ = "Sören Gebbert, Carmen Tawalika"
+__copyright__ = "Copyright 2018-2021, Sören Gebbert, mundialis"
+__maintainer__ = "mundialis"
 
 
+register_processes()
 create_endpoints()
 
 if __name__ == '__main__':

--- a/src/openeo_grass_gis_driver/main.py
+++ b/src/openeo_grass_gis_driver/main.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from openeo_grass_gis_driver.app import flask_app
 from openeo_grass_gis_driver.endpoints import create_endpoints
-from openeo_grass_gis_driver.register_processes import register_processes
+from openeo_grass_gis_driver.register_actinia_processes import \
+    register_processes
 
 
 __license__ = "Apache License, Version 2.0"

--- a/src/openeo_grass_gis_driver/processes.py
+++ b/src/openeo_grass_gis_driver/processes.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from flask_restful import Resource
 from flask import make_response, jsonify
-from openeo_grass_gis_driver.actinia_processing.base import PROCESS_DESCRIPTION_DICT
+from openeo_grass_gis_driver.actinia_processing.base import \
+    ACTINIA_PROCESS_DESCRIPTION_DICT, PROCESS_DESCRIPTION_DICT
 
 __license__ = "Apache License, Version 2.0"
 __author__ = "Sören Gebbert"
@@ -16,7 +17,7 @@ class Processes(Resource):
         Resource.__init__(self)
 
     def get(self):
-        
+
         # can have a query parameter 'limit' to enable pagination
         # get the value of limit (i.e. ?limit=10)
         # limit = request.args.get('limit')
@@ -24,6 +25,9 @@ class Processes(Resource):
         pd_list = list()
         for key in PROCESS_DESCRIPTION_DICT:
             pd = PROCESS_DESCRIPTION_DICT[key]
+            pd_list.append(pd)
+        for key in ACTINIA_PROCESS_DESCRIPTION_DICT:
+            pd = ACTINIA_PROCESS_DESCRIPTION_DICT[key]
             pd_list.append(pd)
 
         response = dict(processes=pd_list, links=[])

--- a/src/openeo_grass_gis_driver/register_actinia_processes.py
+++ b/src/openeo_grass_gis_driver/register_actinia_processes.py
@@ -2,7 +2,7 @@
 from openeo_grass_gis_driver.actinia_processing.config import Config \
     as ActiniaConfig
 from openeo_grass_gis_driver.actinia_processing.base import \
-    PROCESS_DESCRIPTION_DICT
+    ACTINIA_PROCESS_DESCRIPTION_DICT
 from openeo_grass_gis_driver.actinia_processing.actinia_interface import \
     ActiniaInterface
 
@@ -22,5 +22,5 @@ def register_processes():
     if status_code == 200:
         for module in modules:
             # TODO: add logger
-            print("registering %s" % module['id'])
-            PROCESS_DESCRIPTION_DICT[module['id']] = module
+            # print("registering %s" % module['id'])
+            ACTINIA_PROCESS_DESCRIPTION_DICT[module['id']] = module

--- a/src/openeo_grass_gis_driver/register_processes.py
+++ b/src/openeo_grass_gis_driver/register_processes.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from openeo_grass_gis_driver.actinia_processing.config import Config \
+    as ActiniaConfig
+from openeo_grass_gis_driver.actinia_processing.base import \
+    PROCESS_DESCRIPTION_DICT
+from openeo_grass_gis_driver.actinia_processing.actinia_interface import \
+    ActiniaInterface
+
+
+__license__ = "Apache License, Version 2.0"
+__author__ = "Carmen Tawalika"
+__copyright__ = "Copyright 2021 mundialis"
+__maintainer__ = "mundialis"
+
+
+def register_processes():
+
+    iface = ActiniaInterface()
+    iface.set_auth(ActiniaConfig.USER, ActiniaConfig.PASSWORD)
+    status_code, modules = iface.list_modules()
+
+    if status_code == 200:
+        for module in modules:
+            # TODO: add logger
+            print("registering %s" % module['id'])
+            PROCESS_DESCRIPTION_DICT[module['id']] = module


### PR DESCRIPTION
To exploit more functionality of actinia and therefore of GRASS GIS, all modules (grass-modules and actinia-modules) are registered on startup with this PR. This way they appear as processes under `/processes` endpoint. For now, only "id", "description" and "categories" are shown for external processes (depending on actinia-gdi endpoint).

Snippet of response containing default openeo process "variance", grass-module "r.quantile" and actinia-module "slope_aspect":

```
    {
      "deprecated": false,
      "description": "Computes the sample variance of an array of numbers by calculating the square of the standard deviation (see ``sd()``).",
      "experimental": false,
      "id": "variance",
      "links": [],
      "parameters": [
        {
          "deprecated": false,
          "description": "An array of numbers.",
          "experimental": false,
          "name": "data",
          "optional": false,
          "schema": {
            "items": {
              "type": [
                "number",
                "null"
              ]
            },
            "type": "array"
          }
        },
        {
          "default": true,
          "deprecated": false,
          "description": "Indicates whether no-data values are ignored or not.",
          "experimental": false,
          "name": "ignore_nodata",
          "optional": true,
          "schema": {
            "type": "boolean"
          }
        }
      ],
      "returns": {
        "description": "The computed sample variance.",
        "media_type": "application/json",
        "schema": {
          "type": [
            "number",
            "null"
          ]
        }
      },
      "summary": "Variance"
    },
    {
      "categories": [
        "algebra",
        "grass-module",
        "percentile",
        "quantile",
        "raster",
        "statistics"
      ],
      "description": "Compute quantiles using two passes.",
      "id": "r.quantile"
    },
    {
      "categories": [
        "actinia-module"
      ],
      "description": "Calculates slope and aspect of elevation map.",
      "id": "slope_aspect"
    },
```