### PR TITLE
Add more infos to r.slope.aspect

### DIFF
--- a/src/openeo_grass_gis_driver/register_actinia_processes.py
+++ b/src/openeo_grass_gis_driver/register_actinia_processes.py
@@ -24,3 +24,8 @@ def register_processes():
             # TODO: add logger
             # print("registering %s" % module['id'])
             ACTINIA_PROCESS_DESCRIPTION_DICT[module['id']] = module
+
+    # overwrite certain module to collect more information
+    status_code, module = iface.list_module('r.slope.aspect')
+    if status_code == 200:
+        ACTINIA_PROCESS_DESCRIPTION_DICT[module['id']] = module


### PR DESCRIPTION
With this PR, all information from r.slope.aspect are included in process list, created during startup. When this approach is more feasable than collecting this information later, a suitable way needs to be implemented to add all modules on startup alreay (more likely needs to be implemented in actinia-module-plugin).