### PR TITLE
openeo GRASS driver: actinia modules

### DIFF
--- a/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
@@ -320,7 +320,7 @@ class ActiniaInterface(object):
 
         return r.status_code, data
 
-    def list_module(self, module) -> Tuple[int, dict]:
+    def list_module(self, module: str) -> Tuple[int, dict]:
         url = "%(base)s/modules/%(module)s" % {
                  "base": self.base_url, "module": module}
         r = requests.get(url=url, auth=self.auth)

--- a/src/openeo_grass_gis_driver/actinia_processing/base.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/base.py
@@ -310,8 +310,10 @@ def openeo_to_actinia(node: Node) -> Tuple[list, list]:
 
     output_objects = []
 
-    # GRASS module name
-    module_name = node.process_id
+    # openeo process name and GRASS module name
+    process_name = node.process_id
+    # get module name as returned by actinia
+    module_name = ACTINIA_PROCESS_DESCRIPTION_DICT[process_name]["id"]
 
     # get module description from actinia
     # to find out which parameters are input and which are output
@@ -321,10 +323,8 @@ def openeo_to_actinia(node: Node) -> Tuple[list, list]:
     if status_code != 200:
         raise Exception("Unsupported actinia process '%s'" % module_name)
 
-    # openeo-like process name
     rn = randint(0, 1000000)
 
-    process_name = module_name.replace(".", "_")
     actinia_id = "%s_%i" % (process_name, rn)
 
     # create an actinia process chain entry of the form
@@ -351,7 +351,7 @@ def openeo_to_actinia(node: Node) -> Tuple[list, list]:
 
     pc = {}
     pc["id"] = actinia_id
-    pc["module"] = node.process_id
+    pc["module"] = module_name
     pc["inputs"] = []
     pc["flags"] = None
 

--- a/src/openeo_grass_gis_driver/processes_process_id.py
+++ b/src/openeo_grass_gis_driver/processes_process_id.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from flask import make_response, jsonify
+from flask_restful import Resource
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DESCRIPTION_DICT
 from openeo_grass_gis_driver.actinia_processing.base import \
     ACTINIA_PROCESS_DESCRIPTION_DICT
 from openeo_grass_gis_driver.actinia_processing.actinia_interface import \
      ActiniaInterface
-from openeo_grass_gis_driver.authentication import ResourceBase
 
 __license__ = "Apache License, Version 2.0"
 __author__ = "Sören Gebbert"
@@ -15,10 +15,10 @@ __maintainer__ = "Soeren Gebbert"
 __email__ = "soerengebbert@googlemail.com"
 
 
-class ProcessesProcessId(ResourceBase):
+class ProcessesProcessId(Resource):
 
     def __init__(self):
-        ResourceBase.__init__(self)
+        Resource.__init__(self)
 
     def get(self, process_id):
 
@@ -29,7 +29,8 @@ class ProcessesProcessId(ResourceBase):
                 200)
         elif process_id in ACTINIA_PROCESS_DESCRIPTION_DICT:
             iface = ActiniaInterface()
-            status_code, module = iface.list_module(process_id)
+            module_name = ACTINIA_PROCESS_DESCRIPTION_DICT[process_id]["id"]
+            status_code, module = iface.list_module(module_name)
             if status_code == 200:
                 return make_response(jsonify(module), 200)
 

--- a/src/openeo_grass_gis_driver/register_actinia_processes.py
+++ b/src/openeo_grass_gis_driver/register_actinia_processes.py
@@ -23,9 +23,12 @@ def register_processes():
         for module in modules:
             # TODO: add logger
             # print("registering %s" % module['id'])
-            ACTINIA_PROCESS_DESCRIPTION_DICT[module['id']] = module
+            # convert grass module names to openeo process names
+            process = module["id"].replace('.', '_')
+            ACTINIA_PROCESS_DESCRIPTION_DICT[process] = module
 
     # overwrite certain module to collect more information
     status_code, module = iface.list_module('r.slope.aspect')
     if status_code == 200:
-        ACTINIA_PROCESS_DESCRIPTION_DICT[module['id']] = module
+        process = module["id"].replace('.', '_')
+        ACTINIA_PROCESS_DESCRIPTION_DICT[process] = module

--- a/src/openeo_grass_gis_driver/utils/process_graph_examples_v10.py
+++ b/src/openeo_grass_gis_driver/utils/process_graph_examples_v10.py
@@ -786,7 +786,7 @@ ACTINIA_PROCESS = {
                 }
             },
             "compute_slope": {
-                "process_id": "r.slope.aspect",
+                "process_id": "r_slope_aspect",
                 "arguments": {
                     "elevation": {"from_node": "get_elevation_data"},
                     "e": True,


### PR DESCRIPTION
For openeo process names, "only letters (a-z), numbers and underscores" are allowed, see 
https://api.openeo.org/#section/Processes/Defining-Processes

Therefore dots in actinia module names need to be translated to underscores, e.g. r.slope.aspect to r_slope_aspect.
The original actinia module names are still available in the id of the entries of ACTINIA_PROCESS_DESCRIPTION_DICT 
and needed to translate openeo process names to actinia module names.
