### PR TITLE
Url prefix

### DIFF
--- a/src/openeo_grass_gis_driver/app.py
+++ b/src/openeo_grass_gis_driver/app.py
@@ -4,14 +4,14 @@ from flask import Flask
 from flask_restful import Api
 from werkzeug.middleware.proxy_fix import ProxyFix
 
+from openeo_grass_gis_driver.well_known import URL_PREFIX
+
+
 __license__ = "Apache License, Version 2.0"
 __author__ = "Sören Gebbert, Carmen Tawalika"
 __copyright__ = "Copyright 2018-2021, Sören Gebbert, mundialis"
 __maintainer__ = "mundialis"
 
-API_VERSION = "v1.0"
-# This is the URL prefix that must be used in the tests
-URL_PREFIX = "/api/%s" % API_VERSION
 
 flask_app = Flask(__name__)
 flask_app.wsgi_app = ProxyFix(flask_app.wsgi_app, x_for=1, x_host=1, x_proto=1)

--- a/src/openeo_grass_gis_driver/app.py
+++ b/src/openeo_grass_gis_driver/app.py
@@ -4,14 +4,18 @@ from flask import Flask
 from flask_restful import Api
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-__author__ = "Sören Gebbert"
-__copyright__ = "Copyright 2018, Sören Gebbert, mundialis"
-__maintainer__ = "Soeren Gebbert"
-__email__ = "soerengebbert@googlemail.com"
+__license__ = "Apache License, Version 2.0"
+__author__ = "Sören Gebbert, Carmen Tawalika"
+__copyright__ = "Copyright 2018-2021, Sören Gebbert, mundialis"
+__maintainer__ = "mundialis"
+
+API_VERSION = "v1.0"
+# This is the URL prefix that must be used in the tests
+URL_PREFIX = "/api/%s" % API_VERSION
 
 flask_app = Flask(__name__)
 flask_app.wsgi_app = ProxyFix(flask_app.wsgi_app, x_for=1, x_host=1, x_proto=1)
 # as flask CORS lead to unforeseen behaviour in certain cases, we configure
 # headers with nginx and outcomment here.
 # CORS(flask_app, supports_credentials=True)
-flask_api = Api(flask_app)
+flask_api = Api(flask_app, prefix=URL_PREFIX)

--- a/src/openeo_grass_gis_driver/endpoints.py
+++ b/src/openeo_grass_gis_driver/endpoints.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+from flask import make_response, jsonify
+
 from openeo_grass_gis_driver.app import flask_api
 from openeo_grass_gis_driver.authentication import \
      Authentication, OIDCAuthentication
 from openeo_grass_gis_driver.authentication import UserInfo
 from openeo_grass_gis_driver.capabilities import \
-     Capabilities, ServiceTypes, Services
+     Capabilities, ServiceTypes, Services, CAPABILITIES
 from openeo_grass_gis_driver.collections import Collections
 from openeo_grass_gis_driver.collection_information import \
      CollectionInformationResource
@@ -24,18 +26,35 @@ from openeo_grass_gis_driver.udf import Udf
 from openeo_grass_gis_driver.well_known import WellKnown
 
 __license__ = "Apache License, Version 2.0"
-__author__ = "Sören Gebbert"
-__copyright__ = "Copyright 2018, Sören Gebbert, mundialis"
-__maintainer__ = "Soeren Gebbert"
-__email__ = "soerengebbert@googlemail.com"
+__author__ = "Sören Gebbert, Carmen Tawalika"
+__copyright__ = "Copyright 2018-2021, Sören Gebbert, mundialis GmbH & Co. KG"
+__maintainer__ = "mundialis"
+
+
+def add_discovery_endpoints():
+    """ Add endpoints to "app" instead of flask_api to bypass URL_PREFIX for
+    basic discovery endpoints
+    """
+
+    app = flask_api.app
+
+    @app.route('/')
+    def index():
+        return make_response(jsonify(CAPABILITIES), 200)
+
+    @app.route('/.well-known/openeo')
+    def well_known():
+        return WellKnown.get(flask_api)
 
 
 def create_endpoints():
-    """Create all endpoints for the openEO Core API  wrapper
+    """Create all endpoints for the openEO Core API wrapper
     """
+
+    add_discovery_endpoints()
+
     # Capabilities
     flask_api.add_resource(Capabilities, '/')
-    flask_api.add_resource(WellKnown, '/.well-known/openeo')
     flask_api.add_resource(OutputFormats, '/file_formats')
     # /conformance
     flask_api.add_resource(Udf, '/udf_runtimes')

--- a/src/openeo_grass_gis_driver/test_base.py
+++ b/src/openeo_grass_gis_driver/test_base.py
@@ -27,13 +27,15 @@ class TestBase(unittest.TestCase):
 
     def setUp(self):
         self.app = flask_api.app.test_client()
+        self.prefix = flask_api.prefix
         self.gconf = ActiniaConfig()
         self.gconf.PORT = "443"
         self.auth = Headers()
         auth = bytes(self.gconf.USER + ':' + self.gconf.PASSWORD, "utf-8")
         encodeAuth = base64.b64encode(auth).decode()
         self.auth.add('Authorization', 'Basic ' + encodeAuth)
-        response = self.app.get('/credentials/basic', headers=self.auth)
+        response = self.app.get(
+            self.prefix + '/credentials/basic', headers=self.auth)
         resp_data = json.loads(response.data.decode())
         self.auth.set(
             'Authorization',

--- a/src/openeo_grass_gis_driver/well_known.py
+++ b/src/openeo_grass_gis_driver/well_known.py
@@ -5,7 +5,14 @@ from flask import make_response, jsonify, request
 
 __license__ = "Apache License, Version 2.0"
 __author__ = "Carmen Tawalika"
-__copyright__ = "2018-present mundialis GmbH & Co. KG"
+__copyright__ = "2018-2021 mundialis GmbH & Co. KG"
+
+
+API_VERSION = "1.0.1"
+API_SHORT_VERSION = "v%s.%s" % (
+    API_VERSION.split('.')[0], API_VERSION.split('.')[1])
+# This is the URL prefix that is used by app.py and must be used in the tests
+URL_PREFIX = "/api/%s" % API_SHORT_VERSION
 
 
 class WellKnown(Resource):
@@ -15,11 +22,11 @@ class WellKnown(Resource):
 
     def get(self):
 
-        host_url = request.host_url
+        url = '%s%s/' % (request.host_url.strip('/'), URL_PREFIX)
 
         version_list = list()
-        version_list.append({"url": host_url + "api/v1.0/",
-                             "api_version": "1.0.1",
+        version_list.append({"url": url,
+                             "api_version": API_VERSION,
                              "production": False})
 
         resp = dict()

--- a/tests/test_actinia_interface.py
+++ b/tests/test_actinia_interface.py
@@ -92,8 +92,9 @@ class ActiniaInterfaceTestCase(TestBase):
 
     def test_layer_exists_2_error(self):
         iface = ActiniaInterface(self.gconf)
+        layer_name = "latlong_wgs84.modis_ndvi_global.strds.ndvi_16_5600m_nope"
         status = iface.check_layer_exists(
-            layer_name="latlong_wgs84.modis_ndvi_global.strds.ndvi_16_5600m_nope")
+            layer_name=layer_name)
         self.assertFalse(status)
 
     def test_async_persistent_processing(self):

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from flask import json
 import unittest
+
 from openeo_grass_gis_driver.capabilities import CAPABILITIES, SERVICE_TYPES
 from openeo_grass_gis_driver.jobs import OUTPUT_FORMATS
 from openeo_grass_gis_driver.test_base import TestBase
@@ -15,21 +16,23 @@ __email__ = "soerengebbert@googlemail.com"
 class CapabilitiesTestCase(TestBase):
 
     def test_capabilities(self):
-        response = self.app.get('/', headers=self.auth)
+        response = self.app.get(self.prefix + '/', headers=self.auth)
         print(response.data)
 
         self.assertEqual(json.loads(response.data.decode()),
                          CAPABILITIES)
 
     def test_ouput_formats(self):
-        response = self.app.get('/file_formats', headers=self.auth)
+        response = self.app.get(
+            self.prefix + '/file_formats', headers=self.auth)
         print(response.data)
 
         self.assertEqual(json.loads(response.data.decode()),
                          OUTPUT_FORMATS)
 
     def test_service_types(self):
-        response = self.app.get('/service_types', headers=self.auth)
+        response = self.app.get(
+            self.prefix + '/service_types', headers=self.auth)
         print(response.data)
 
         self.assertEqual(json.loads(response.data.decode()),

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -2,6 +2,7 @@
 import unittest
 from flask import json
 from pprint import pprint
+
 from openeo_grass_gis_driver.test_base import TestBase
 
 __license__ = "Apache License, Version 2.0"
@@ -18,7 +19,8 @@ class DataTestCase(TestBase):
 
         :return:
         """
-        response = self.app.get('/collections', headers=self.auth)
+        response = self.app.get(
+            self.prefix + '/collections', headers=self.auth)
         data = json.loads(response.data.decode())
 
         pprint(data)
@@ -41,6 +43,7 @@ class DataTestCase(TestBase):
 
     def test_raster_collections_id_1(self):
         response = self.app.get(
+            self.prefix +
             '/collections/nc_spm_08.landsat.raster.lsat5_1987_10',
             headers=self.auth)
         self.assertEqual(response.status_code, 200)
@@ -51,6 +54,7 @@ class DataTestCase(TestBase):
 
     def test_raster_collections_id_2(self):
         response = self.app.get(
+            self.prefix +
             '/collections/nc_spm_08.PERMANENT.raster.elevation',
             headers=self.auth)
         self.assertEqual(response.status_code, 200)
@@ -61,6 +65,7 @@ class DataTestCase(TestBase):
 
     def test_vector_collections_id_2(self):
         response = self.app.get(
+            self.prefix +
             '/collections/nc_spm_08.PERMANENT.raster.elevation',
             headers=self.auth)
         self.assertEqual(response.status_code, 200)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2,6 +2,7 @@
 import unittest
 import pprint
 from flask import json
+
 from openeo_grass_gis_driver.test_base import TestBase
 from openeo_grass_gis_driver.utils.process_graph_examples_v10 import \
     FILTER_BBOX, NDVI_STRDS, ACTINIA_PROCESS
@@ -24,7 +25,7 @@ class JobsTestCase(TestBase):
 
     def setUp(self):
         TestBase.setUp(self)
-        response = self.app.delete('/jobs', headers=self.auth)
+        response = self.app.delete(self.prefix + '/jobs', headers=self.auth)
         self.assertEqual(204, response.status_code)
 
     def test_job_creation_1(self):
@@ -33,6 +34,7 @@ class JobsTestCase(TestBase):
         JOB_TEMPLATE["process"] = FILTER_BBOX["process"]
 
         response = self.app.post(
+            self.prefix +
             '/jobs',
             data=json.dumps(JOB_TEMPLATE),
             content_type="application/json",
@@ -40,7 +42,7 @@ class JobsTestCase(TestBase):
         self.assertEqual(201, response.status_code)
         job_id = response.get_data().decode("utf-8")
 
-        response = self.app.get('/jobs', headers=self.auth)
+        response = self.app.get(self.prefix + '/jobs', headers=self.auth)
         data = json.loads(response.get_data().decode("utf-8"))
         pprint.pprint(data)
         self.assertEqual(200, response.status_code)
@@ -50,7 +52,8 @@ class JobsTestCase(TestBase):
 
         self.assertEqual(job_id, data["jobs"][0]["id"])
 
-        response = self.app.get(f'/jobs/{job_id}', headers=self.auth)
+        response = self.app.get(
+            f'{self.prefix}/jobs/{job_id}', headers=self.auth)
         self.assertEqual(200, response.status_code)
 
         data = json.loads(response.get_data().decode("utf-8"))
@@ -64,6 +67,7 @@ class JobsTestCase(TestBase):
         JOB_TEMPLATE["process"] = NDVI_STRDS["process"]
 
         response = self.app.post(
+            self.prefix +
             '/jobs',
             data=json.dumps(JOB_TEMPLATE),
             content_type="application/json",
@@ -71,14 +75,16 @@ class JobsTestCase(TestBase):
         self.assertEqual(201, response.status_code)
         job_id = response.get_data().decode("utf-8")
 
-        response = self.app.get(f'/jobs/{job_id}', headers=self.auth)
+        response = self.app.get(
+            f'{self.prefix}/jobs/{job_id}', headers=self.auth)
         self.assertEqual(200, response.status_code)
 
         data = json.loads(response.get_data().decode("utf-8"))
         pprint.pprint(data)
         self.assertEqual(job_id, data["id"])
 
-        response = self.app.get(f'/jobs/{job_id}' + "_nope", headers=self.auth)
+        response = self.app.get(
+            f'{self.prefix}/jobs/{job_id}' + "_nope", headers=self.auth)
         self.assertEqual(404, response.status_code)
 
     def test_job_creation_deletion_1(self):
@@ -87,6 +93,7 @@ class JobsTestCase(TestBase):
         JOB_TEMPLATE["process"] = NDVI_STRDS["process"]
 
         response = self.app.post(
+            self.prefix +
             '/jobs',
             data=json.dumps(JOB_TEMPLATE),
             content_type="application/json",
@@ -94,16 +101,20 @@ class JobsTestCase(TestBase):
         self.assertEqual(201, response.status_code)
         job_id = response.get_data().decode("utf-8")
 
-        response = self.app.get(f'/jobs/{job_id}', headers=self.auth)
+        response = self.app.get(
+            f'{self.prefix}/jobs/{job_id}', headers=self.auth)
         self.assertEqual(200, response.status_code)
 
-        response = self.app.delete(f'/jobs/{job_id}', headers=self.auth)
+        response = self.app.delete(
+            f'{self.prefix}/jobs/{job_id}', headers=self.auth)
         self.assertEqual(204, response.status_code)
 
-        response = self.app.delete(f'/jobs/{job_id}', headers=self.auth)
+        response = self.app.delete(
+            f'{self.prefix}/jobs/{job_id}', headers=self.auth)
         self.assertEqual(404, response.status_code)
 
-        response = self.app.get(f'/jobs/{job_id}', headers=self.auth)
+        response = self.app.get(
+            f'{self.prefix}/jobs/{job_id}', headers=self.auth)
         self.assertEqual(404, response.status_code)
 
     def test_actinia_process(self):
@@ -112,6 +123,7 @@ class JobsTestCase(TestBase):
         JOB_TEMPLATE["process"] = ACTINIA_PROCESS["process"]
 
         response = self.app.post(
+            self.prefix +
             '/jobs',
             data=json.dumps(JOB_TEMPLATE),
             content_type="application/json",
@@ -119,16 +131,20 @@ class JobsTestCase(TestBase):
         self.assertEqual(201, response.status_code)
         job_id = response.get_data().decode("utf-8")
 
-        response = self.app.get(f'/jobs/{job_id}', headers=self.auth)
+        response = self.app.get(
+            f'{self.prefix}/jobs/{job_id}', headers=self.auth)
         self.assertEqual(200, response.status_code)
 
-        response = self.app.delete(f'/jobs/{job_id}', headers=self.auth)
+        response = self.app.delete(
+            f'{self.prefix}/jobs/{job_id}', headers=self.auth)
         self.assertEqual(204, response.status_code)
 
-        response = self.app.delete(f'/jobs/{job_id}', headers=self.auth)
+        response = self.app.delete(
+            f'{self.prefix}/jobs/{job_id}', headers=self.auth)
         self.assertEqual(404, response.status_code)
 
-        response = self.app.get(f'/jobs/{job_id}', headers=self.auth)
+        response = self.app.get(
+            f'{self.prefix}/jobs/{job_id}', headers=self.auth)
         self.assertEqual(404, response.status_code)
 
 
@@ -136,7 +152,7 @@ class JobsTestResultsCase(TestBase):
 
     def setUp(self):
         TestBase.setUp(self)
-        response = self.app.delete('/jobs', headers=self.auth)
+        response = self.app.delete(self.prefix + '/jobs', headers=self.auth)
         self.assertEqual(204, response.status_code)
 
     def test_job_creation_and_processing_filter_box(self):
@@ -145,6 +161,7 @@ class JobsTestResultsCase(TestBase):
         JOB_TEMPLATE["process"] = FILTER_BBOX["process"]
 
         response = self.app.post(
+            self.prefix +
             '/jobs',
             data=json.dumps(JOB_TEMPLATE),
             content_type="application/json",
@@ -153,19 +170,22 @@ class JobsTestResultsCase(TestBase):
         job_id = response.get_data().decode("utf-8")
 
         # Get job information
-        response = self.app.get(f'/jobs/{job_id}/results', headers=self.auth)
+        response = self.app.get(
+            f'{self.prefix}/jobs/{job_id}/results', headers=self.auth)
         self.assertEqual(200, response.status_code)
         data = response.get_data().decode("utf-8")
         pprint.pprint(data)
 
         # Start the job
-        response = self.app.post(f'/jobs/{job_id}/results', headers=self.auth)
+        response = self.app.post(
+            f'{self.prefix}/jobs/{job_id}/results', headers=self.auth)
         data = response.get_data().decode("utf-8")
         pprint.pprint(data)
         self.assertEqual(202, response.status_code)
 
         # get job information
-        response = self.app.get(f'/jobs/{job_id}/results', headers=self.auth)
+        response = self.app.get(
+            f'{self.prefix}/jobs/{job_id}/results', headers=self.auth)
         data = response.get_data().decode("utf-8")
         pprint.pprint(data)
         self.assertEqual(200, response.status_code)
@@ -224,6 +244,7 @@ class JobsTestResultsCase(TestBase):
         JOB_TEMPLATE["process"] = FILTER_BBOX["process"]
 
         response = self.app.post(
+            self.prefix +
             '/jobs',
             data=json.dumps(JOB_TEMPLATE),
             content_type="application/json",
@@ -233,7 +254,8 @@ class JobsTestResultsCase(TestBase):
         print(job_id)
 
         # Get job information
-        response = self.app.get(f'/jobs/{job_id}', headers=self.auth)
+        response = self.app.get(
+            f'{self.prefix}/jobs/{job_id}', headers=self.auth)
         data = response.get_data().decode("utf-8")
         print(data)
         self.assertEqual(200, response.status_code)
@@ -241,14 +263,15 @@ class JobsTestResultsCase(TestBase):
         JOB_TEMPLATE["process"] = NDVI_STRDS["process"]
 
         response = self.app.patch(
-            f'/jobs/{job_id}',
+            f'{self.prefix}/jobs/{job_id}',
             data=json.dumps(JOB_TEMPLATE),
             content_type="application/json",
             headers=self.auth)
         self.assertEqual(204, response.status_code)
 
         # Get job information
-        response = self.app.get(f'/jobs/{job_id}', headers=self.auth)
+        response = self.app.get(
+            f'{self.prefix}/jobs/{job_id}', headers=self.auth)
         data = response.get_data().decode("utf-8")
         print(data)
         self.assertEqual(200, response.status_code)

--- a/tests/test_process_definitions.py
+++ b/tests/test_process_definitions.py
@@ -139,7 +139,9 @@ class ProcessDefinitionTestCase(TestBase):
 #        output_names, pc = g.to_actinia_process_list()
 #        pprint([str(o) for o in output_names])
 #        pprint(pc)
-#        self.assertTrue("nc_spm_08.PERMANENT.raster.elevation" in [o.full_name() for o in output_names])
+#        self.assertTrue(
+#            "nc_spm_08.PERMANENT.raster.elevation"
+#             in [o.full_name() for o in output_names])
 #        self.assertEqual(len(pc), 3)
 #
 #    def test_rgb_raster_export(self):
@@ -148,9 +150,15 @@ class ProcessDefinitionTestCase(TestBase):
 #        output_names, pc = g.to_actinia_process_list()
 #        pprint([str(o) for o in output_names])
 #        pprint(pc)
-#        self.assertTrue("nc_spm_08.landsat.raster.lsat7_2000_10" in [o.full_name() for o in output_names])
-#        self.assertTrue("nc_spm_08.landsat.raster.lsat7_2000_20" in [o.full_name() for o in output_names])
-#        self.assertTrue("nc_spm_08.landsat.raster.lsat7_2000_30" in [o.full_name() for o in output_names])
+#        self.assertTrue(
+#            "nc_spm_08.landsat.raster.lsat7_2000_10"
+#            in [o.full_name() for o in output_names])
+#        self.assertTrue(
+#            "nc_spm_08.landsat.raster.lsat7_2000_20"
+#             in [o.full_name() for o in output_names])
+#        self.assertTrue(
+#            "nc_spm_08.landsat.raster.lsat7_2000_30"
+#             in [o.full_name() for o in output_names])
 #        self.assertEqual(len(pc), 8)
 #
 #    def test_zonal_statistics(self):
@@ -159,7 +167,9 @@ class ProcessDefinitionTestCase(TestBase):
 #        output_names, pc = g.to_actinia_process_list()
 #        pprint([str(o) for o in output_names])
 #        pprint(pc)
-#        self.assertTrue('None.None.strds.LST_Day_monthly_load_collection' in [o.full_name() for o in output_names])
+#        self.assertTrue(
+#            'None.None.strds.LST_Day_monthly_load_collection'
+#             in [o.full_name() for o in output_names])
 #        self.assertEqual(len(pc), 10)
 
     def test_openeo_usecase_1(self):

--- a/tests/test_process_graph.py
+++ b/tests/test_process_graph.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 import unittest
 import pprint
 from flask import json
+
 from openeo_grass_gis_driver.test_base import TestBase
 from openeo_grass_gis_driver.utils.process_graph_examples_v10 import \
     FILTER_BBOX
@@ -25,18 +26,20 @@ class ProcessGraphTestCase(TestBase):
 
     def setUp(self):
         TestBase.setUp(self)
-        response = self.app.delete('/process_graphs', headers=self.auth)
+        response = self.app.delete(
+            self.prefix + '/process_graphs', headers=self.auth)
         self.assertEqual(204, response.status_code)
 
     def test_job_creation_1(self):
         """Run the test in the ephemeral database
         """
-        PROCESS_CHAIN_TEMPLATE["process_graph"] = FILTER_BBOX["process"]["process_graph"]
+        pc = FILTER_BBOX["process"]["process_graph"]
+        PROCESS_CHAIN_TEMPLATE["process_graph"] = pc
 
         process_graph_id = f"user-graph-{str(uuid4())}"
 
         response = self.app.put(
-            f'/process_graphs/{process_graph_id}',
+            f'{self.prefix}/process_graphs/{process_graph_id}',
             data=json.dumps(PROCESS_CHAIN_TEMPLATE),
             content_type="application/json",
             headers=self.auth)
@@ -48,7 +51,8 @@ class ProcessGraphTestCase(TestBase):
         self.assertEqual(200, response.status_code)
         # process_graph_id = response.get_data().decode("utf-8")
 
-        response = self.app.get('/process_graphs', headers=self.auth)
+        response = self.app.get(
+            self.prefix + '/process_graphs', headers=self.auth)
         self.assertEqual(200, response.status_code)
 
         data = json.loads(response.get_data().decode("utf-8"))
@@ -57,7 +61,7 @@ class ProcessGraphTestCase(TestBase):
         self.assertEqual(process_graph_id, data["processes"][0]["id"])
 
         response = self.app.get(
-            f'/process_graphs/{process_graph_id}',
+            f'{self.prefix}/process_graphs/{process_graph_id}',
             headers=self.auth)
         self.assertEqual(200, response.status_code)
 
@@ -72,11 +76,12 @@ class ProcessGraphTestCase(TestBase):
     def test_job_creation_2(self):
         """Run the test in the ephemeral database
         """
-        PROCESS_CHAIN_TEMPLATE["process_graph"] = FILTER_BBOX["process"]["process_graph"]
+        pc = FILTER_BBOX["process"]["process_graph"]
+        PROCESS_CHAIN_TEMPLATE["process_graph"] = pc
 
         process_graph_id = f"user-graph-{str(uuid4())}"
         response = self.app.put(
-            f'/process_graphs/{process_graph_id}',
+            f'{self.prefix}/process_graphs/{process_graph_id}',
             data=json.dumps(PROCESS_CHAIN_TEMPLATE),
             content_type="application/json",
             headers=self.auth)
@@ -89,7 +94,7 @@ class ProcessGraphTestCase(TestBase):
         # process_graph_id = response.get_data().decode("utf-8")
 
         response = self.app.get(
-            f'/process_graphs/{process_graph_id}',
+            f'{self.prefix}/process_graphs/{process_graph_id}',
             headers=self.auth)
         self.assertEqual(200, response.status_code)
 
@@ -102,16 +107,17 @@ class ProcessGraphTestCase(TestBase):
             data["process_graph"])
 
         response = self.app.delete(
-            f'/process_graphs/{process_graph_id}',
+            f'{self.prefix}/process_graphs/{process_graph_id}',
             headers=self.auth)
         self.assertEqual(204, response.status_code)
 
         response = self.app.get(
-            f'/process_graphs/{process_graph_id}',
+            f'{self.prefix}/process_graphs/{process_graph_id}',
             headers=self.auth)
         self.assertEqual(400, response.status_code)
 
-        response = self.app.get('/process_graphs', headers=self.auth)
+        response = self.app.get(
+            self.prefix + '/process_graphs', headers=self.auth)
         self.assertEqual(200, response.status_code)
 
         data = json.loads(response.get_data().decode("utf-8"))
@@ -144,7 +150,8 @@ class ProcessGraphTestCase(TestBase):
 #        self.assertEqual(FILTER_BBOX["process_graph"], data["process_graph"])
 #
 #        # Modify graph
-#        PROCESS_CHAIN_TEMPLATE["process_graph"] = ZONAL_STATISTICS["process_graph"]
+#        pc = ZONAL_STATISTICS["process_graph"]
+#        PROCESS_CHAIN_TEMPLATE["process_graph"] = pc
 #
 #        response = self.app.patch(f'/process_graphs/{process_graph_id}',
 #                                  data=json.dumps(PROCESS_CHAIN_TEMPLATE),

--- a/tests/test_process_graph_generation.py
+++ b/tests/test_process_graph_generation.py
@@ -64,9 +64,13 @@ class GraphValidationTestCase(TestBase):
 #        self.assertIsNone(pg.node_dict["zonal_statistics_1"].child)
 #        self.assertEqual(pg.node_dict["zonal_statistics_1"],
 #                         pg.node_dict["get_b08_data"].child)
-#        self.assertEqual(pg.node_dict["zonal_statistics_1"].get_parent_by_name("data"), pg.node_dict["get_b08_data"])
+#        self.assertEqual(
+#            pg.node_dict["zonal_statistics_1"].get_parent_by_name("data"),
+#            pg.node_dict["get_b08_data"])
 #        self.assertEqual(1, len(pg.node_dict["zonal_statistics_1"].parents))
-#        self.assertTrue(pg.node_dict["get_b08_data"] in pg.node_dict["zonal_statistics_1"].parents)
+#        self.assertTrue(
+#            pg.node_dict["get_b08_data"]
+#            in pg.node_dict["zonal_statistics_1"].parents)
 
     def test_graph_creation_graph_daterange(self):
 
@@ -80,7 +84,8 @@ class GraphValidationTestCase(TestBase):
 
         self.assertEqual(0, len(pg.node_dict["filter_daterange_1"].children))
         self.assertTrue(
-            pg.node_dict["filter_daterange_1"] in pg.node_dict["get_strds_data"].children)
+            pg.node_dict["filter_daterange_1"]
+            in pg.node_dict["get_strds_data"].children)
         self.assertEqual(
             pg.node_dict["filter_daterange_1"].get_parent_by_name("data"),
             pg.node_dict["get_strds_data"])

--- a/tests/test_process_graph_validation.py
+++ b/tests/test_process_graph_validation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 from flask import json
+
 from openeo_grass_gis_driver.test_base import TestBase
 from openeo_grass_gis_driver.utils.process_graph_examples_v10 import \
     FILTER_BBOX, NDVI_STRDS, GET_DATA_1, GET_DATA_3, DATERANGE, ACTINIA_PROCESS
@@ -18,6 +19,7 @@ class GraphValidationTestCase(TestBase):
         """Run the validation test
         """
         response = self.app.post(
+            self.prefix +
             '/validation',
             data=json.dumps(FILTER_BBOX),
             content_type="application/json",
@@ -28,6 +30,7 @@ class GraphValidationTestCase(TestBase):
         """Run the validation test
         """
         response = self.app.post(
+            self.prefix +
             '/validation',
             data=json.dumps(NDVI_STRDS),
             content_type="application/json",
@@ -38,6 +41,7 @@ class GraphValidationTestCase(TestBase):
         """Run the validation test
         """
         response = self.app.post(
+            self.prefix +
             '/validation',
             data=json.dumps(GET_DATA_1),
             content_type="application/json",
@@ -48,6 +52,7 @@ class GraphValidationTestCase(TestBase):
         """Run the validation test
         """
         response = self.app.post(
+            self.prefix +
             '/validation',
             data=json.dumps(GET_DATA_3),
             content_type="application/json",
@@ -58,6 +63,7 @@ class GraphValidationTestCase(TestBase):
         """Run the validation test
         """
         response = self.app.post(
+            self.prefix +
             '/validation',
             data=json.dumps(DATERANGE),
             content_type="application/json",
@@ -68,48 +74,9 @@ class GraphValidationTestCase(TestBase):
         """Run the validation test
         """
         response = self.app.post(
+            self.prefix +
             '/validation',
             data=json.dumps(ACTINIA_PROCESS),
-            content_type="application/json",
-            headers=self.auth)
-        self.assertEqual(response.status_code, 200)
-
-    def no_support_test_6_graph_zonal_statistics(self):
-        """Run the validation test
-        """
-        response = self.app.post(
-            '/validation',
-            data=json.dumps(ZONAL_STATISTICS),
-            content_type="application/json",
-            headers=self.auth)
-        self.assertEqual(response.status_code, 200)
-
-    def no_support_test_9_graph_raster_export(self):
-        """Run the validation test
-        """
-        response = self.app.post(
-            '/validation',
-            data=json.dumps(RASTER_EXPORT),
-            content_type="application/json",
-            headers=self.auth)
-        self.assertEqual(response.status_code, 200)
-
-    def no_support_test_10_graph_map_algebra(self):
-        """Run the validation test
-        """
-        response = self.app.post(
-            '/validation',
-            data=json.dumps(MAP_ALGEBRA),
-            content_type="application/json",
-            headers=self.auth)
-        self.assertEqual(response.status_code, 200)
-
-    def no_support_test_11_graph_temporal_algebra(self):
-        """Run the validation test
-        """
-        response = self.app.post(
-            '/validation',
-            data=json.dumps(TEMPORAL_ALGEBRA),
             content_type="application/json",
             headers=self.auth)
         self.assertEqual(response.status_code, 200)

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -2,6 +2,7 @@
 import unittest
 from pprint import pprint
 from flask import json
+
 from openeo_grass_gis_driver.test_base import TestBase
 
 __license__ = "Apache License, Version 2.0"
@@ -14,7 +15,7 @@ __email__ = "soerengebbert@googlemail.com"
 class ProcessesTestCase(TestBase):
 
     def test_processes(self):
-        response = self.app.get('/processes', headers=self.auth)
+        response = self.app.get(self.prefix + '/processes', headers=self.auth)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode())
         pprint(data)
@@ -29,13 +30,15 @@ class ProcessesTestCase(TestBase):
 #        pprint(data)
 #
     def test_process_filter_bbox(self):
-        response = self.app.get('/processes/filter_bbox', headers=self.auth)
+        response = self.app.get(
+            self.prefix + '/processes/filter_bbox', headers=self.auth)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode())
         pprint(data)
 
     def test_process_get_data(self):
         response = self.app.get(
+            self.prefix +
             '/processes/load_collection',
             headers=self.auth)
         self.assertEqual(response.status_code, 200)
@@ -43,7 +46,8 @@ class ProcessesTestCase(TestBase):
         pprint(data)
 
     def test_process_NDVI(self):
-        response = self.app.get('/processes/ndvi', headers=self.auth)
+        response = self.app.get(
+            self.prefix + '/processes/ndvi', headers=self.auth)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode())
         pprint(data)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -33,6 +33,7 @@ class PreviewTestCase(TestBase):
         """Test the filter box process
         """
         response = self.app.post(
+            self.prefix +
             '/result',
             data=json.dumps(FILTER_BBOX),
             content_type="application/json",
@@ -49,8 +50,10 @@ class PreviewTestCase(TestBase):
         """
 
         fbox = FILTER_BBOX
-        fbox["process"]["process_graph"]["get_data_1"]["arguments"]["id"] = "nc_spm_08.PERMANENT.raster.elevation_nonon"
+        aid = "nc_spm_08.PERMANENT.raster.elevation_nonon"
+        fbox["process"]["process_graph"]["get_data_1"]["arguments"]["id"] = aid
         response = self.app.post(
+            self.prefix +
             '/result',
             data=json.dumps(fbox),
             content_type="application/json",
@@ -65,6 +68,7 @@ class PreviewTestCase(TestBase):
         """Test the get data process to get raster data
         """
         response = self.app.post(
+            self.prefix +
             '/result',
             data=json.dumps(GET_DATA_1),
             content_type="application/json",
@@ -79,6 +83,7 @@ class PreviewTestCase(TestBase):
         """Test the get data process to get strds data
         """
         response = self.app.post(
+            self.prefix +
             '/result',
             data=json.dumps(GET_DATA_3),
             content_type="application/json",
@@ -93,6 +98,7 @@ class PreviewTestCase(TestBase):
         """Run the daterange process
         """
         response = self.app.post(
+            self.prefix +
             '/result',
             data=json.dumps(DATERANGE),
             content_type="application/json",

--- a/tests/test_udf.py
+++ b/tests/test_udf.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 from flask import json
+
 from openeo_grass_gis_driver.test_base import TestBase
 from openeo_grass_gis_driver.udf import SUPPORTED_UDF
 from openeo_grass_gis_driver.udf_lang_udf_type import python_udfs
@@ -15,7 +16,7 @@ __email__ = "soerengebbert@googlemail.com"
 class UdfTestCase(TestBase):
 
     def otest_udf(self):
-        response = self.app.get('/udf', headers=self.auth)
+        response = self.app.get(self.prefix + '/udf', headers=self.auth)
         data = json.loads(response.data.decode())
         print(data)
 
@@ -23,6 +24,7 @@ class UdfTestCase(TestBase):
 
     def otest_udf_lang(self):
         response = self.app.get(
+            self.prefix +
             '/udf/python/udf_reduce_time',
             headers=self.auth)
         data = json.loads(response.data.decode())

--- a/tests/test_well_known.py
+++ b/tests/test_well_known.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from openeo_grass_gis_driver.test_base import TestBase
+
+__license__ = "Apache License, Version 2.0"
+__author__ = "Carmen Tawalika"
+__copyright__ = "Copyright 2021, mundialis"
+__maintainer__ = "mundialis"
+
+
+class UdfTestCase(TestBase):
+
+    def test_well_known(self):
+        response = self.app.get('/.well-known/openeo', headers=self.auth)
+        self.assertEqual(response.status_code, 200)
+
+    def test_well_known_with_api_prefix(self):
+        response = self.app.get(
+            self.prefix + '/.well-known/openeo', headers=self.auth)
+        self.assertEqual(response.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
To make deployment independent of nginx, the openeo-grassgis-driver is - with this PR - able to add the API version prefix itself. As this is an api breaking change when used without nginx, a major release will be necessary afterwards.