### PR TITLE
Avoid os error

### DIFF
--- a/src/openeo_grass_gis_driver/actinia_processing/config.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/config.py
@@ -53,9 +53,12 @@ class Configfile:
             print("Could not find any config file, using default values.")
             return
 
-        with open(GENERATED_CONFIG, 'w') as configfile:
-            config.write(configfile)
-        print("Configuration written to " + GENERATED_CONFIG)
+        # commented out due to
+        # OSError: [Errno 30] Read-only file system
+        # TODO: is there a better solution to avoid this?
+        # with open(GENERATED_CONFIG, 'w') as configfile:
+        #     config.write(configfile)
+        # print("Configuration written to " + GENERATED_CONFIG)
 
         # CONFIG
         if config.has_section("ACTINIA"):


### PR DESCRIPTION
When deploying with kubernetes, the config is mounted as a configmap. This way, it is mounted read only and on startup the following error appears:
```
OSError: [Errno 30] Read-only file system: '/etc/default/openeo-grassgis-driver/openeo-grassgis-driver.cfg'
```
This PR comments according code out. It was only used for debugging reasons. Maybe a better solution can be found.