### PR TITLE
Parse locations from config as array

### DIFF
--- a/src/openeo_grass_gis_driver/actinia_processing/config.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/config.py
@@ -67,7 +67,10 @@ class Configfile:
             if config.has_option("ACTINIA", "PORT"):
                 ACTINIA.PORT = config.get("ACTINIA", "PORT")
             if config.has_option("ACTINIA", "LOCATIONS"):
-                ACTINIA.LOCATIONS = config.get("ACTINIA", "LOCATIONS")
+                locations = config.get("ACTINIA", "LOCATIONS")
+                # keep config values consistent, convert string to array here
+                ACTINIA.LOCATIONS = [
+                    i.strip('" ') for i in locations.strip('[]').split(',')]
             if config.has_option("ACTINIA", "USER"):
                 ACTINIA.USER = config.get("ACTINIA", "USER")
             if config.has_option("ACTINIA", "PASSWORD"):


### PR DESCRIPTION
Most values can be configured via separate config file. For the locations this seemed possible, but apparent array `LOCATIONS = ["nc_spm_08", "utm32n", "latlong_wgs84"]` will be simply interpreted as string by configparser. This leads to following error when requesting the collections endpoint:
`An internal error occurred while catching mapset from location [!"`

This PR keeps the appearence of an array in the config file and reads it in as an array instead of string.