### PR TITLE
Make lint check green

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,6 +5,7 @@
 # E501 line too long (85 > 79 characters)
 
 per-file-ignores =
+    ./docs/conf.py
     ./src/openeo_grass_gis_driver/actinia_processing/*.py: E501
     ./src/openeo_grass_gis_driver/actinia_processing/__init__.py: F401
     ./src/openeo_grass_gis_driver/models/*.py: E501

--- a/.flake8
+++ b/.flake8
@@ -5,10 +5,19 @@
 # E501 line too long (85 > 79 characters)
 
 per-file-ignores =
-    ./src/openeo_grass_gis_driver/models/job_schemas.py: W605
-    ./src/openeo_grass_gis_driver/models/collection_schemas.py: W605
-    ./src/openeo_grass_gis_driver/models/service_schemas.py: W605
+    ./src/openeo_grass_gis_driver/actinia_processing/*.py: E501
     ./src/openeo_grass_gis_driver/actinia_processing/__init__.py: F401
+    ./src/openeo_grass_gis_driver/models/*.py: E501
+    ./src/openeo_grass_gis_driver/models/collection_schemas.py: W605, E501
+    ./src/openeo_grass_gis_driver/models/job_schemas.py: W605, E501
+    ./src/openeo_grass_gis_driver/models/service_schemas.py: W605
+    ./src/openeo_grass_gis_driver/collection_information.py: E501
+    ./src/openeo_grass_gis_driver/jobs_job_id.py: E501
+    ./src/openeo_grass_gis_driver/jobs_job_id_estimate.py: E501
+    ./src/openeo_grass_gis_driver/jobs_job_id_logs.py: E501
+    ./src/openeo_grass_gis_driver/jobs_job_id_results.py: E501
+    ./src/openeo_grass_gis_driver/udf.py: E501
+    ./src/openeo_grass_gis_driver/udf_lang_udf_type.py: E501
     ./src/openeo_grass_gis_driver/utils/process_graph_examples_v03.py: E501
     ./src/openeo_grass_gis_driver/utils/process_graph_examples_v04.py: E501
     ./src/openeo_grass_gis_driver/utils/process_graph_examples_v10.py: E501

--- a/src/openeo_grass_gis_driver/actinia_processing/base.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/base.py
@@ -392,15 +392,15 @@ def openeo_to_actinia(node: Node) -> Tuple[list, list]:
             # check schema subtype of parameter and compare with
             # datatype of data_object
             if ao["schema"]["subtype"] == "cell" and \
-               data_object.datatype != GrassDataType.RASTER:
+                    data_object.datatype != GrassDataType.RASTER:
                 raise Exception(
                     "Wrong input data type, expecting 'cell'")
             elif ao["schema"]["subtype"] == "strds" and \
-               data_object.datatype != GrassDataType.STRDS:
+                    data_object.datatype != GrassDataType.STRDS:
                 raise Exception(
                     "Wrong input data type, expecting 'strds'")
             elif ao["schema"]["subtype"] == "vector" and \
-               data_object.datatype != GrassDataType.VECTOR:
+                    data_object.datatype != GrassDataType.VECTOR:
                 raise Exception(
                     "Wrong input data type, expecting 'vector'")
         elif ao["schema"]["type"] == "boolean":

--- a/src/openeo_grass_gis_driver/endpoints.py
+++ b/src/openeo_grass_gis_driver/endpoints.py
@@ -6,7 +6,7 @@ from openeo_grass_gis_driver.authentication import \
      Authentication, OIDCAuthentication
 from openeo_grass_gis_driver.authentication import UserInfo
 from openeo_grass_gis_driver.capabilities import \
-     Capabilities, ServiceTypes, Services, CAPABILITIES, \
+     Capabilities, ServiceTypes, Services, \
      replace_links_in_capabilities
 from openeo_grass_gis_driver.collections import Collections
 from openeo_grass_gis_driver.collection_information import \


### PR DESCRIPTION
This PR fixes all lint errors except `501 - line too long` which it now ignores per file/folder. Current status :
```
2     E127 continuation line over-indented for visual indent
409   E501 line too long (120 > 79 characters)
1     F401 'openeo_grass_gis_driver.capabilities.CAPABILITIES' imported but unused
1     F811 redefinition of unused 'CAPABILITIES' from line 8
```
status with this PR:
```
0
```