### PR TITLE
Request all modules from actinia

### DIFF
--- a/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
@@ -330,14 +330,7 @@ class ActiniaInterface(object):
         return self._send_post_request(url=url, process_chain=process_chain)
 
     def list_modules(self) -> Tuple[int, dict]:
-        # Request raster modules only because requesting all modules
-        # would take too long.
-        url = "%(base)s/modules?family=r&record=full" % {"base": self.base_url}
-        # if short startup time is required for development,
-        # add additional filter:
-        # url = ("%(base)s/modules?tag=slope&record=full" % {
-        #       "base": self.base_url})
-
+        url = "%(base)s/modules?record=full" % {"base": self.base_url}
         r = requests.get(url=url, auth=self.auth)
         data = r.text
 


### PR DESCRIPTION
Currently, the modules requested from actinia contain only the `r` family, as everything else would lead to a timeout. With the new caching functionality of actinia ([Add redis cache for grass modules #9](https://github.com/mundialis/actinia-module-plugin/pull/9)) it is possible to use all addons. This new feature of actinia is already deployed at [actinia-dev.mundialis.de](https://actinia-dev.mundialis.de/api/v1/modules?record=full) which is the default actinia installation for openeo-grassgis-driver.

This PR reads in all actinia + GRASS GIS modules and integrates them in the `/processes` endpoint response.

Is this a wise thing to do? Because most likely the different GRASS GIS addons (`v`-family, `db`-family, ...) cannot be used as is in a process graph, because the openeo datatypes won't fit. On the other hand it would reveal all the possibilities and might encourage to find suitable ways of how to deal with them. What do you think?

