### PR TITLE
Remove raster + vector data from collections...

### DIFF
--- a/src/openeo_grass_gis_driver/collections.py
+++ b/src/openeo_grass_gis_driver/collections.py
@@ -68,5 +68,26 @@ class Collections(Resource):
                                           location, mapset)))
                         COLLECTIONS_LIST.append(ds)
 
+                    # # List vector maps from the GRASS location
+                    # status_code, vector_data = self.iface.list_vector(
+                    #     location=location, mapset=mapset)
+                    # if status_code != 200:
+                    #     return make_response(jsonify(
+                    #         {"description": "An internal error occurred "
+                    #          "while catching vector layers!"}, 400))
+
+                    # for entry in vector_data:
+                    #     vector_id = ("%s.%s.vector.%s" % (
+                    #         location, mapset, entry))
+                    #     ds = CollectionEntry(
+                    #         id=vector_id,
+                    #         title="Vector dataset",
+                    #         license="proprietary",
+                    #         description=("Raster Vector GRASS GIS location "
+                    #                      "mapset path: /%s/%s" % (
+                    #                       location, mapset)))
+                    #     COLLECTIONS_LIST.append(ds)
+
+
         c = Collection(collections=COLLECTIONS_LIST)
         return c.as_response(http_status=200)

--- a/src/openeo_grass_gis_driver/collections.py
+++ b/src/openeo_grass_gis_driver/collections.py
@@ -68,45 +68,5 @@ class Collections(Resource):
                                           location, mapset)))
                         COLLECTIONS_LIST.append(ds)
 
-                    # List raster maps from the GRASS location
-                    status_code, raster_data = self.iface.list_raster(
-                        location=location, mapset=mapset)
-                    if status_code != 200:
-                        return make_response(jsonify(
-                            {"description": "An internal error occurred "
-                             "while catching raster layers!"}, 400))
-
-                    for entry in raster_data:
-                        raster_id = ("%s.%s.raster.%s" % (
-                            location, mapset, entry))
-                        ds = CollectionEntry(
-                            id=raster_id,
-                            title="Raster dataset",
-                            license="proprietary",
-                            description=("Raster dataset GRASS GIS location/"
-                                         "mapset path: /%s/%s" % (
-                                          location, mapset)))
-                        COLLECTIONS_LIST.append(ds)
-
-                    # List vector maps from the GRASS location
-                    status_code, vector_data = self.iface.list_vector(
-                        location=location, mapset=mapset)
-                    if status_code != 200:
-                        return make_response(jsonify(
-                            {"description": "An internal error occurred "
-                             "while catching vector layers!"}, 400))
-
-                    for entry in vector_data:
-                        vector_id = ("%s.%s.vector.%s" % (
-                            location, mapset, entry))
-                        ds = CollectionEntry(
-                            id=vector_id,
-                            title="Vector dataset",
-                            license="proprietary",
-                            description=("Raster Vector GRASS GIS location "
-                                         "mapset path: /%s/%s" % (
-                                          location, mapset)))
-                        COLLECTIONS_LIST.append(ds)
-
         c = Collection(collections=COLLECTIONS_LIST)
         return c.as_response(http_status=200)

--- a/src/openeo_grass_gis_driver/collections.py
+++ b/src/openeo_grass_gis_driver/collections.py
@@ -88,6 +88,5 @@ class Collections(Resource):
                     #                       location, mapset)))
                     #     COLLECTIONS_LIST.append(ds)
 
-
         c = Collection(collections=COLLECTIONS_LIST)
         return c.as_response(http_status=200)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -25,9 +25,10 @@ class DataTestCase(TestBase):
 
         pprint(data)
 
-        dsets = ["nc_spm_08.landsat.strds.lsat5_1987"]
-               # "nc_spm_08.PERMANENT.vector.lakes",
-
+        dsets = [
+            "nc_spm_08.landsat.strds.lsat5_1987"
+            # "nc_spm_08.PERMANENT.vector.lakes"
+        ]
         data_id_list = []
 
         for entry in data["collections"]:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -25,9 +25,7 @@ class DataTestCase(TestBase):
 
         pprint(data)
 
-        dsets = ["nc_spm_08.landsat.raster.lsat5_1987_10",
-                 "nc_spm_08.PERMANENT.vector.lakes",
-                 "nc_spm_08.PERMANENT.raster.elevation"]
+        dsets = ["nc_spm_08.landsat.strds.lsat5_1987"]
 
         data_id_list = []
 
@@ -44,36 +42,13 @@ class DataTestCase(TestBase):
     def test_raster_collections_id_1(self):
         response = self.app.get(
             self.prefix +
-            '/collections/nc_spm_08.landsat.raster.lsat5_1987_10',
+            '/collections/nc_spm_08.landsat.strds.lsat5_1987',
             headers=self.auth)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode())
         pprint(data)
 
-        self.assertEqual(data["id"], "nc_spm_08.landsat.raster.lsat5_1987_10")
-
-    def test_raster_collections_id_2(self):
-        response = self.app.get(
-            self.prefix +
-            '/collections/nc_spm_08.PERMANENT.raster.elevation',
-            headers=self.auth)
-        self.assertEqual(response.status_code, 200)
-        data = json.loads(response.data.decode())
-        pprint(data)
-
-        self.assertEqual(data["id"], "nc_spm_08.PERMANENT.raster.elevation")
-
-    def test_vector_collections_id_2(self):
-        response = self.app.get(
-            self.prefix +
-            '/collections/nc_spm_08.PERMANENT.raster.elevation',
-            headers=self.auth)
-        self.assertEqual(response.status_code, 200)
-        data = json.loads(response.data.decode())
-        pprint(data)
-
-        self.assertEqual(data["id"], "nc_spm_08.PERMANENT.raster.elevation")
-
+        self.assertEqual(data["id"], "nc_spm_08.landsat.strds.lsat5_1987")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -50,5 +50,6 @@ class DataTestCase(TestBase):
 
         self.assertEqual(data["id"], "nc_spm_08.landsat.strds.lsat5_1987")
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -26,6 +26,7 @@ class DataTestCase(TestBase):
         pprint(data)
 
         dsets = ["nc_spm_08.landsat.strds.lsat5_1987"]
+               # "nc_spm_08.PERMANENT.vector.lakes",
 
         data_id_list = []
 
@@ -39,7 +40,7 @@ class DataTestCase(TestBase):
 
         self.assertTrue(found)
 
-    def test_raster_collections_id_1(self):
+    def test_strds_collections_id_1(self):
         response = self.app.get(
             self.prefix +
             '/collections/nc_spm_08.landsat.strds.lsat5_1987',
@@ -49,6 +50,17 @@ class DataTestCase(TestBase):
         pprint(data)
 
         self.assertEqual(data["id"], "nc_spm_08.landsat.strds.lsat5_1987")
+
+    # def test_vector_collections_id_2(self):
+    #     response = self.app.get(
+    #         self.prefix +
+    #         '/collections/nc_spm_08.PERMANENT.raster.elevation',
+    #     headers=self.auth)
+    #     self.assertEqual(response.status_code, 200)
+    #     data = json.loads(response.data.decode())
+    #     pprint(data)
+
+    #     self.assertEqual(data["id"], "nc_spm_08.PERMANENT.raster.elevation")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
... to only list STRDS in `/collections` endpoint, because these are the datacubes which can be processed with openEO api