### PR TITLE
Add docker build + push action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,39 @@
+name: Docker build
+
+on:
+￼ push:
+￼   paths-ignore: ['docs/**']
+￼   branches: [ master, gha-docker ]
+
+jobs:
+  docker:
+    name: docker build
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN  }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          tags: mmacata/openeo-grassgis-driver:latest
+          file: docker/Dockerfile
+          no-cache: false
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ name: Docker build and push
 
 on:
   push:
-    branches: [master, gha-docker]
+    branches: [master]
     tags: ['*.*.*']
     paths-ignore: ['docs/**']
   release:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,7 @@
 # # type=semver,pattern={{major}} # tag = 1
 # latest=auto # takes care of tag latest
 
+
 name: Docker build
 
 on:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,9 @@
 name: Docker build
 
 on:
-￼ push:
-￼   paths-ignore: ['docs/**']
-￼   branches: [ master, gha-docker ]
+  push:
+    paths-ignore: ['docs/**']
+    branches: [ master, gha-docker ]
 
 jobs:
   docker:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,6 @@
 # # type=semver,pattern={{major}} # tag = 1
 # latest=auto # takes care of tag latest
 
-
 name: Docker build
 
 on:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,59 +1,47 @@
-# type=ref,event=branch # on push, tag = main
+# https://github.com/marketplace/actions/build-and-push-docker-images
+# https://github.com/marketplace/actions/docker-metadata-action
 # type=ref,event=tag # on push tag, tag = 1.2.3
 # type=sha # tag = sha-ad132f5
-# # type=semver,pattern={{raw}} # tag = <tag>
-# # type=semver,pattern={{version}} # tag = 1.2.3
-# # type=semver,pattern={{major}}.{{minor}} # tag = 1.2
-# # type=semver,pattern={{major}} # tag = 1
 # latest=auto # takes care of tag latest
 
-
-name: Docker build
+name: Docker build and push
 
 on:
   push:
-    branches: [ master, gha-docker ]
-    tags: [ '*.*.*' ]
+    branches: [master, gha-docker]
+    tags: ['*.*.*']
     paths-ignore: ['docs/**']
   release:
     types: [published, created]
 
 jobs:
   docker:
-    name: docker build
+    name: docker build and push
     runs-on: ubuntu-latest
+
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
-      -
-        name: Docker metadata
-        # https://github.com/marketplace/actions/docker-metadata-action
+      - name: Create image and tag names
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: mmacata/openeo-grassgis-driver
+          images: mundialis/openeo-grassgis-driver
           tags: |
-            type=ref,event=branch
             type=ref,event=tag
             type=sha
           flavor: |
             latest=auto
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN  }}
-      -
-        name: Build and push
-        # https://github.com/marketplace/actions/build-and-push-docker-images
+      - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
@@ -61,6 +49,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           context: .
           file: docker/Dockerfile
-      -
-        name: Image digest
+      - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,21 @@
+# type=ref,event=branch # on push, tag = main
+# type=ref,event=tag # on push tag, tag = 1.2.3
+# type=sha # tag = sha-ad132f5
+# # type=semver,pattern={{raw}} # tag = <tag>
+# # type=semver,pattern={{version}} # tag = 1.2.3
+# # type=semver,pattern={{major}}.{{minor}} # tag = 1.2
+# # type=semver,pattern={{major}} # tag = 1
+# latest=auto # takes care of tag latest
+
 name: Docker build
 
 on:
   push:
-    paths-ignore: ['docs/**']
     branches: [ master, gha-docker ]
+    tags: [ '*.*.*' ]
+    paths-ignore: ['docs/**']
+  release:
+    types: [published, created]
 
 jobs:
   docker:
@@ -13,6 +25,19 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+      -
+        name: Docker metadata
+        # https://github.com/marketplace/actions/docker-metadata-action
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: mmacata/openeo-grassgis-driver
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+          flavor: |
+            latest=auto
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -27,13 +52,14 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN  }}
       -
         name: Build and push
+        # https://github.com/marketplace/actions/build-and-push-docker-images
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: false
-          tags: mmacata/openeo-grassgis-driver:latest
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          context: .
           file: docker/Dockerfile
-          no-cache: false
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Dockerhub no longer runs autobuilds itself. To have current docker images, github actions are now used to build and push docker images.
This PR adds a github action, which

- on push to branch `master`, build and push image to dockerhub with tag ref - e.g. `sha-7cc2976`
- on release, build and push image to dockerhub with tag containing semver release version - e.g. `1.2.3`
- updates tag `latest` where appropriate