### PR TITLE
use unique output names

### DIFF
--- a/src/openeo_grass_gis_driver/actinia_processing/add_dimension_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/add_dimension_process.py
@@ -124,6 +124,7 @@ def get_process_list(node: Node):
         output_objects.append(data_object)
         node.add_output(data_object)
 
+    # dummy process, does nothing
     # pc = create_process_chain_entry(input_object, output_object)
     # process_list.append(pc)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/aggregate_spatial_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/aggregate_spatial_process.py
@@ -4,7 +4,6 @@ import json
 
 from openeo_grass_gis_driver.models.process_graph_schemas import \
    ProcessGraphNode, ProcessGraph
-
 from openeo_grass_gis_driver.actinia_processing.base import PROCESS_DICT, \
     PROCESS_DESCRIPTION_DICT, Node, check_node_parents, DataObject
 from openeo_grass_gis_driver.models.process_schemas import \

--- a/src/openeo_grass_gis_driver/actinia_processing/apply_mask_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/apply_mask_process.py
@@ -2,7 +2,8 @@
 from random import randint
 import json
 from openeo_grass_gis_driver.actinia_processing.base import \
-    Node, check_node_parents, DataObject, GrassDataType
+    Node, check_node_parents, DataObject, GrassDataType, \
+    create_ouput_name
 from openeo_grass_gis_driver.actinia_processing.base import \
     PROCESS_DICT, PROCESS_DESCRIPTION_DICT
 from openeo_grass_gis_driver.models.process_graph_schemas import \
@@ -136,7 +137,7 @@ def get_process_list(node: Node):
             mask_object = node.get_parent_by_name("mask").output_objects[i]
 
         output_object = DataObject(
-            name=f"{input_object.name}_{PROCESS_NAME}",
+            name=create_ouput_name(input_object.name, PROCESS_NAME),
             datatype=GrassDataType.RASTER)
         output_objects.append(output_object)
         node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/apply_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/apply_process.py
@@ -5,7 +5,8 @@ import json
 from openeo_grass_gis_driver.models.process_graph_schemas import \
     ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.actinia_processing.base import \
-    Node, check_node_parents, DataObject, GrassDataType
+    Node, check_node_parents, DataObject, GrassDataType, \
+    create_ouput_name
 from openeo_grass_gis_driver.actinia_processing.base import \
     PROCESS_DICT, PROCESS_DESCRIPTION_DICT
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -222,7 +223,7 @@ def get_process_list(node: Node):
     for input_object in node.get_parent_by_name("data").output_objects:
 
         output_object = DataObject(
-            name=f"{input_object.name}_{PROCESS_NAME}",
+            name=create_ouput_name(input_object.name, PROCESS_NAME),
             datatype=output_datatype)
         output_objects.append(output_object)
         node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/array_element_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/array_element_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-    check_node_parents, DataObject, GrassDataType
+    check_node_parents, DataObject, GrassDataType, \
+    create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
     ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -116,7 +117,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/base.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/base.py
@@ -2,6 +2,7 @@
 from enum import Enum
 from typing import Set, Dict, Optional, Tuple, Union
 from random import randint
+import uuid
 
 # This is the process dictionary that is used to store all processes of
 # the Actinia wrapper
@@ -454,7 +455,7 @@ def openeo_to_actinia(node: Node) -> Tuple[list, list]:
                 # in order to distinguish between different outputs
                 # of the same module
                 output_object = DataObject(
-                    name=f"{data_object.name}_{process_name}",
+                    name=create_ouput_name(data_object.name, process_name),
                     datatype=datatype)
                 param = {"param": key,
                          "value": output_object.grass_name()}
@@ -477,3 +478,16 @@ def check_node_parents(node: Node) -> Tuple[list, list]:
         input_objects.extend(i)
 
     return input_objects, process_list
+
+
+def create_ouput_name(input: str, process_name: str):
+    new_uuid = uuid.uuid4().hex
+
+    # names must start with a letter
+    if input.find("uuid") == 0 and "_" in input:
+        insuffix = input.split("_", 1)[1]
+        output = f"uuid{new_uuid}_{insuffix}_{process_name}"
+    else:
+        output = f"uuid{new_uuid}_{input}_{process_name}"
+
+    return output

--- a/src/openeo_grass_gis_driver/actinia_processing/evi_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/evi_process.py
@@ -4,10 +4,10 @@ import json
 
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraph, ProcessGraphNode
-
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DICT, PROCESS_DESCRIPTION_DICT, Node, \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_schemas import \
      Parameter, ProcessDescription, ReturnValue, ProcessExample
 
@@ -183,7 +183,7 @@ def get_process_list(node: Node):
     output_objects.extend(list(blue_input_objects))
 
     output_object = DataObject(
-        name=f"{red_strds.name}_{PROCESS_NAME}",
+        name=create_ouput_name(red_strds.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
     node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/filter_bands_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/filter_bands_process.py
@@ -4,7 +4,8 @@ from random import randint
 from typing import Tuple
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -171,7 +172,7 @@ def get_process_list(node: Node) -> Tuple[list, list]:
         parent_name="data").output_objects)[-1]
 
     output_object = DataObject(
-        name=f"{data_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(data_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
     node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/filter_spatial_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/filter_spatial_process.py
@@ -3,7 +3,8 @@ import json
 from random import randint
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -147,7 +148,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/filter_temporal_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/filter_temporal_process.py
@@ -3,7 +3,8 @@ from random import randint
 import json
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DICT, PROCESS_DESCRIPTION_DICT, Node, \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -168,7 +169,7 @@ def get_process_list(node: Node):
             continue
 
         output_object = DataObject(
-            name=f"{data_object.name}_{PROCESS_NAME}",
+            name=create_ouput_name(data_object.name, PROCESS_NAME),
             datatype=GrassDataType.STRDS)
         output_objects.append(output_object)
         node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/hants_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/hants_process.py
@@ -5,7 +5,8 @@ import json
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.actinia_processing.base import \
-     Node, check_node_parents, DataObject, GrassDataType
+     Node, check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DICT, PROCESS_DESCRIPTION_DICT
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -203,7 +204,7 @@ def get_process_list(node: Node):
 
         # multiple strds as input ?
         output_object = DataObject(
-            name=f"{data_object.name}_{PROCESS_NAME}",
+            name=create_ouput_name(data_object.name, PROCESS_NAME),
             datatype=GrassDataType.STRDS)
         output_objects.append(output_object)
         node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/load_collection_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/load_collection_process.py
@@ -4,10 +4,9 @@ import json
 
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraph, ProcessGraphNode
-
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DICT, PROCESS_DESCRIPTION_DICT, Node, \
-     check_node_parents, DataObject
+     check_node_parents, DataObject, create_ouput_name
 from openeo_grass_gis_driver.models.process_schemas import \
      Parameter, ProcessDescription, ReturnValue, ProcessExample
 
@@ -366,7 +365,7 @@ def get_process_list(node: Node):
     if input_object.is_strds() and \
        (temporal_extent is not None or bands is not None):
         output_object = DataObject(
-            name=f"{input_object.name}_{PROCESS_NAME}",
+            name=create_ouput_name(input_object.name, PROCESS_NAME),
             datatype=input_object.datatype)
     else:
         output_object = input_object

--- a/src/openeo_grass_gis_driver/actinia_processing/logic_and_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/logic_and_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -111,7 +112,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/logic_if_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/logic_if_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -114,7 +115,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/logic_not_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/logic_not_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -103,7 +104,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/logic_or_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/logic_or_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -112,7 +113,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/logic_xor_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/logic_xor_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -112,7 +113,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/mask_invalid_values_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/mask_invalid_values_process.py
@@ -7,7 +7,8 @@ from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_schemas import \
      Parameter, ProcessDescription, ReturnValue, ProcessExample
 from .base import PROCESS_DICT, PROCESS_DESCRIPTION_DICT, Node
@@ -144,7 +145,7 @@ def get_process_list(node: Node) -> Tuple[list, list]:
     for data_object in input_objects:
 
         output_object = DataObject(
-            name=f"{data_object.name}_{PROCESS_NAME}",
+            name=create_ouput_name(data_object.name, PROCESS_NAME),
             datatype=GrassDataType.STRDS)
         output_objects.append(output_object)
         node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/mask_polygon_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/mask_polygon_process.py
@@ -3,7 +3,8 @@ import json
 from random import randint
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -207,7 +208,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/mask_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/mask_process.py
@@ -7,7 +7,8 @@ from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_schemas import \
      Parameter, ProcessDescription, ReturnValue, ProcessExample
 from .base import PROCESS_DICT, PROCESS_DESCRIPTION_DICT, Node
@@ -162,7 +163,7 @@ def get_process_list(node: Node) -> Tuple[list, list]:
             parent_name="mask").output_objects)[0]
 
     output_object = DataObject(
-        name=f"{data_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(data_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
     node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/math_abs_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_abs_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -104,7 +105,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_add_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_add_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -112,7 +113,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_clip_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_clip_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -119,7 +120,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_divide_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_divide_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -112,7 +113,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_eq_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_eq_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -122,7 +123,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_exp_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_exp_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -103,7 +104,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_gt_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_gt_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -105,7 +106,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_gte_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_gte_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -105,7 +106,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_int_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_int_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -103,7 +104,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_isnan_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_isnan_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -97,7 +98,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_isnodata_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_isnodata_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -97,7 +98,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_ln_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_ln_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -102,7 +103,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_log_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_log_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -112,7 +113,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_lt_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_lt_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -105,7 +106,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_lte_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_lte_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -105,7 +106,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_max_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_max_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -118,7 +119,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_mean_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_mean_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -118,7 +119,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_median_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_median_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -121,7 +122,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_min_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_min_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -118,7 +119,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_mod_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_mod_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -112,7 +113,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_multiply_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_multiply_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -112,7 +113,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_neq_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_neq_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -122,7 +123,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_normdiff_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_normdiff_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -105,7 +106,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_power_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_power_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -112,7 +113,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_product_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_product_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -116,7 +117,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_quantiles_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_quantiles_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -150,7 +151,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_sd_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_sd_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -118,7 +119,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_sgn_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_sgn_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -103,7 +104,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_sqrt_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_sqrt_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -103,7 +104,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_subtract_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_subtract_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -112,7 +113,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_sum_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_sum_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -117,7 +118,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/math_variance_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/math_variance_process.py
@@ -2,7 +2,8 @@
 import json
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -117,7 +118,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/merge_cubes_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/merge_cubes_process.py
@@ -3,7 +3,8 @@ import json
 from random import randint
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -164,7 +165,7 @@ def get_process_list(node: Node):
     cube2_object = list(cube2_objects)[-1]
 
     output_object = DataObject(
-        name=f"{cube1_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(cube1_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
     node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/multilayer_mask_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/multilayer_mask_process.py
@@ -5,7 +5,8 @@ import json
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraph, ProcessGraphNode
 from openeo_grass_gis_driver.actinia_processing.base import \
-     Node, check_node_parents, DataObject, GrassDataType
+     Node, check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DICT, PROCESS_DESCRIPTION_DICT
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -138,7 +139,7 @@ def get_process_list(node: Node):
 
     data_object = list(input_objects)[-1]
     output_object = DataObject(
-        name=f"{data_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(data_object.name, PROCESS_NAME),
         datatype=GrassDataType.RASTER)
     output_objects.append(output_object)
     node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/ndvi_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/ndvi_process.py
@@ -6,7 +6,8 @@ from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraph, ProcessGraphNode
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DICT, PROCESS_DESCRIPTION_DICT, Node, \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_schemas import \
      Parameter, ProcessDescription, ReturnValue, ProcessExample
 
@@ -143,7 +144,7 @@ def get_process_list(node: Node):
     output_objects.extend(list(input_objects))
 
     output_object = DataObject(
-        name=f"{input_strds.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_strds.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
     node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/normalized_difference_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/normalized_difference_process.py
@@ -7,7 +7,8 @@ from openeo_grass_gis_driver.models.process_graph_schemas import \
 
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DICT, PROCESS_DESCRIPTION_DICT, Node, \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_schemas import \
      Parameter, ProcessDescription, ReturnValue, ProcessExample
 
@@ -146,7 +147,7 @@ def get_process_list(node: Node):
     output_objects.extend(list(band2_input_objects))
 
     output_object = DataObject(
-        name=f"{band1_strds.name}_{PROCESS_NAME}",
+        name=create_ouput_name(band1_strds.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
     node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/percentile_time_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/percentile_time_process.py
@@ -6,7 +6,8 @@ from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     Node, check_node_parents, DataObject, GrassDataType
+     Node, check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DICT, PROCESS_DESCRIPTION_DICT
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -115,7 +116,7 @@ def get_process_list(node: Node):
         # multiple strds as input ?
         # multiple raster layers as output !
         output_object = DataObject(
-            name=f"{data_object.name}_{PROCESS_NAME}",
+            name=create_ouput_name(data_object.name, PROCESS_NAME),
             datatype=GrassDataType.STRDS)
         output_objects.append(output_object)
         node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/reduce_dimension_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/reduce_dimension_process.py
@@ -5,7 +5,8 @@ import json
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.actinia_processing.base import \
-     Node, check_node_parents, DataObject, GrassDataType
+     Node, check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DICT, PROCESS_DESCRIPTION_DICT
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -339,7 +340,7 @@ def get_process_list(node: Node):
     for input_object in node.get_parent_by_name("data").output_objects:
 
         output_object = DataObject(
-            name=f"{input_object.name}_{PROCESS_NAME}",
+            name=create_ouput_name(input_object.name, PROCESS_NAME),
             datatype=output_datatype)
         output_objects.append(output_object)
         node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/reduce_time_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/reduce_time_process.py
@@ -5,7 +5,8 @@ import json
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.actinia_processing.base import \
-     Node, check_node_parents, DataObject, GrassDataType
+     Node, check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DICT, PROCESS_DESCRIPTION_DICT
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -134,7 +135,7 @@ def get_process_list(node: Node):
     for input_object in node.get_parent_by_name("data").output_objects:
 
         output_object = DataObject(
-            name=f"{input_object.name}_{PROCESS_NAME}",
+            name=create_ouput_name(input_object.name, PROCESS_NAME),
             datatype=GrassDataType.RASTER)
         output_objects.append(output_object)
         node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/rename_labels_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/rename_labels_process.py
@@ -3,7 +3,8 @@ from random import randint
 import json
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DICT, PROCESS_DESCRIPTION_DICT, Node, \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -157,7 +158,7 @@ def get_process_list(node: Node):
                 PROCESS_NAME)
 
         output_object = DataObject(
-            name=f"{data_object.name}_{PROCESS_NAME}",
+            name=create_ouput_name(data_object.name, PROCESS_NAME),
             datatype=GrassDataType.STRDS)
         output_objects.append(output_object)
         node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/resample_spatial_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/resample_spatial_process.py
@@ -6,7 +6,8 @@ from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     Node, check_node_parents, DataObject, GrassDataType
+     Node, check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DICT, PROCESS_DESCRIPTION_DICT
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -157,7 +158,7 @@ def get_process_list(node: Node):
         # multiple strds as input ?
         # multiple raster layers as output !
         output_object = DataObject(
-            name=f"{input_object.name}_{PROCESS_NAME}",
+            name=create_ouput_name(input_object.name, PROCESS_NAME),
             datatype=GrassDataType.STRDS)
         output_objects.append(output_object)
         node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/run_udf_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/run_udf_process.py
@@ -4,7 +4,8 @@ from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     Node, check_node_parents, DataObject, GrassDataType
+     Node, check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.actinia_processing.base import \
      PROCESS_DICT, PROCESS_DESCRIPTION_DICT
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -144,8 +145,8 @@ def create_process_chain_entry(input_object, python_file_url,
 
 
 def get_process_list(node: Node):
-    """Analyse the process description and return the Actinia process chain and the name of the processing result layer
-    which is a single raster layer
+    """Analyse the process description and return the Actinia process chain
+    and the name of the processing result layer which is a single raster layer
 
     :param args: The process description
     :return: (output_names, actinia_process_list)
@@ -168,7 +169,7 @@ def get_process_list(node: Node):
     for input_object in input_objects:
 
         output_object = DataObject(
-            name=f"{input_object.name}_{PROCESS_NAME}",
+            name=create_ouput_name(input_object.name, PROCESS_NAME),
             datatype=GrassDataType.STRDS)
         output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/scale_minmax_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/scale_minmax_process.py
@@ -7,7 +7,8 @@ from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_schemas import \
      Parameter, ProcessDescription, ReturnValue, ProcessExample
 from .base import PROCESS_DICT, PROCESS_DESCRIPTION_DICT, Node
@@ -126,7 +127,7 @@ def get_process_list(node: Node) -> Tuple[list, list]:
     for input_object in node.get_parent_by_name("data").output_objects:
 
         output_object = DataObject(
-            name=f"{input_object.name}_{PROCESS_NAME}",
+            name=create_ouput_name(input_object.name, PROCESS_NAME),
             datatype=GrassDataType.RASTER)
         output_objects.append(output_object)
         node.add_output(output_object=output_object)

--- a/src/openeo_grass_gis_driver/actinia_processing/trim_cube_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/trim_cube_process.py
@@ -3,7 +3,8 @@ import json
 from random import randint
 
 from openeo_grass_gis_driver.actinia_processing.base import \
-     check_node_parents, DataObject, GrassDataType
+     check_node_parents, DataObject, GrassDataType, \
+     create_ouput_name
 from openeo_grass_gis_driver.models.process_graph_schemas import \
      ProcessGraphNode, ProcessGraph
 from openeo_grass_gis_driver.models.process_schemas import \
@@ -108,7 +109,7 @@ def get_process_list(node: Node):
     input_object = list(input_objects)[-1]
 
     output_object = DataObject(
-        name=f"{input_object.name}_{PROCESS_NAME}",
+        name=create_ouput_name(input_object.name, PROCESS_NAME),
         datatype=GrassDataType.STRDS)
     output_objects.append(output_object)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/udf_reduce_time.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/udf_reduce_time.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from openeo_grass_gis_driver.actinia_processing.base import \
      process_node_to_actinia_process_chain,\
-     PROCESS_DICT, PROCESS_DESCRIPTION_DICT
+     PROCESS_DICT, PROCESS_DESCRIPTION_DICT, \
+     create_ouput_name
 from openeo_grass_gis_driver.actinia_processing.actinia_interface import \
      ActiniaInterface
 
@@ -76,7 +77,7 @@ def get_process_list(args):
 
         location, mapset, datatype, layer_name = ActiniaInterface.layer_def_to_components(
             input_name)
-        output_name = "%s_%s" % (layer_name, PROCESS_NAME)
+        output_name = create_ouput_name(layer_name, PROCESS_NAME)
         output_names.append(output_name)
 
         if "python_file_url" in args:

--- a/tests/test_process_definitions.py
+++ b/tests/test_process_definitions.py
@@ -111,7 +111,7 @@ class ProcessDefinitionTestCase(TestBase):
         output_names, pc = g.to_actinia_process_list()
         pprint(output_names)
         pprint(pc)
-        self.assertEqual(len(pc), 4)
+        self.assertEqual(len(pc), 5)
         self.assertTrue(pc[0]["module"] == "t.info")
         self.assertTrue(pc[1]["module"] == "g.region.bbox")
         self.assertTrue(pc[2]["module"] == "t.rast.extract")
@@ -129,9 +129,11 @@ class ProcessDefinitionTestCase(TestBase):
         self.assertTrue(pc[2]["module"] == "t.rast.extract")
         self.assertTrue(pc[3]["module"] == "t.rast.ndvi")
         self.assertTrue(pc[4]["module"] == "t.rast.colors")
+        strlen = len("lsat5_1987_load_collection_ndvi")
+        # first part of name is uuid<uuid>_
         self.assertTrue(
             "lsat5_1987_load_collection_ndvi" in [
-                o.name for o in output_names])
+                o.name[-strlen:] for o in output_names])
 
 #    def test_raster_export(self):
 #
@@ -178,7 +180,7 @@ class ProcessDefinitionTestCase(TestBase):
         output_names, pc = g.to_actinia_process_list()
         pprint([str(o) for o in output_names])
         pprint(pc)
-        self.assertEqual(len(pc), 8)
+        self.assertEqual(len(pc), 9)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, processes might overwrite each other's results if the same process is used repeatedly with the same input. This PR creates unique output names.
The most important change is the new function `create_output_name()` in https://github.com/Open-EO/openeo-grassgis-driver/blob/output_uuid/src/openeo_grass_gis_driver/actinia_processing/base.py#L483