### PR TITLE
openeo-grass-driver: fix bbox axis order

### DIFF
--- a/src/openeo_grass_gis_driver/collection_information.py
+++ b/src/openeo_grass_gis_driver/collection_information.py
@@ -88,9 +88,11 @@ def coordinate_transform_extent_to_EPSG_4326(
 
     source = osr.SpatialReference()
     source.ImportFromWkt(crs)
+    source.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
 
     target = osr.SpatialReference()
     target.ImportFromEPSG(4326)
+    target.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
 
     transform = osr.CoordinateTransformation(source, target)
 


### PR DESCRIPTION
The spatial extents of a raster data cube must be given with a bbox of the form [xmin, ymin, xmax, ymax], irrespective of the axis order of the used CRS. The default CRS is EPSG:4326 where by definition y is the first axis and x is the second axis, resulting in a bbox of [ymin, xmin, ymax, xmax]. This PR makes reported bboxes conform to openeo specification, irrespective of the CRS axis order specification.

This PR assumes that GDAL 3+ is used, but does not test for it.