### PR TITLE
openeo GRASS driver: map math functions

### DIFF
--- a/src/openeo_grass_gis_driver/actinia_processing/apply_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/apply_process.py
@@ -30,13 +30,15 @@ OPERATOR_DICT = {
     'gte': '>=',
     'lt': '<',
     'lte': '<=',
-    'and': '&&'
+    'and': '&&',
+    'or': '||'
 }
 
 # translate openeo functions to r.mapcalc functions
 FN_DICT = {
     'ln': 'log',
-    'power': 'pow'
+    'power': 'pow',
+    'absolute': 'abs'
 }
 
 

--- a/src/openeo_grass_gis_driver/actinia_processing/reduce_dimension_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/reduce_dimension_process.py
@@ -16,6 +16,7 @@ __license__ = "Apache License, Version 2.0"
 
 PROCESS_NAME = "reduce_dimension"
 
+# translate openeo operators to r.mapcalc operators
 OPERATOR_DICT = {
     'sum': '+',
     'add': '+',
@@ -30,6 +31,14 @@ OPERATOR_DICT = {
     'lt': '<',
     'lte': '<=',
     'and': '&&'
+    'or': '||'
+}
+
+# translate openeo functions to r.mapcalc functions
+FN_DICT = {
+    'ln': 'log',
+    'power': 'pow',
+    'absolute': 'abs'
 }
 
 
@@ -287,6 +296,8 @@ def serialize_tree(tree):
                 results.append(serialize_tree(node))
             return '(' + (' ' + operator + ' ').join(results) + ')'
         else:
+            if operator in FN_DICT:
+                operator = FN_DICT[tree['operator']]
             results = []
             for node in tree['children']:
                 results.append(serialize_tree(node))


### PR DESCRIPTION
The openeo `absolute` function needs to be mapped to the `r.mapcalc` `abs` function.
Note that some openeo functions are still not supported by the openeo GRASS driver, e.g. `product`.