### PR TITLE
openeo GRASS driver: improve GRASS module wrapping

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -17,6 +17,7 @@ per-file-ignores =
     ./src/openeo_grass_gis_driver/jobs_job_id_estimate.py: E501
     ./src/openeo_grass_gis_driver/jobs_job_id_logs.py: E501
     ./src/openeo_grass_gis_driver/jobs_job_id_results.py: E501
+    ./src/openeo_grass_gis_driver/register_actinia_processes.py: E501
     ./src/openeo_grass_gis_driver/udf.py: E501
     ./src/openeo_grass_gis_driver/udf_lang_udf_type.py: E501
     ./src/openeo_grass_gis_driver/utils/process_graph_examples_v03.py: E501

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,7 @@ Flask-RESTful==0.3.8
 sqlitedict==1.7.0
 gunicorn
 
+
 # needed to build documentation
+docutils==0.16
 Sphinx==3.4.3

--- a/src/openeo_grass_gis_driver/actinia_processing/base.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/base.py
@@ -17,6 +17,27 @@ from openeo_grass_gis_driver.models.process_graph_schemas import ProcessGraph
 ACTINIA_OPENEO_PROCESS_DESCRIPTION_DICT = {}
 # mapping of openeo process ids to actinia process ids
 OPENEO_ACTINIA_ID_DICT = {}
+# list of t.* GRASS modules needing special treatment because of a
+# basename option (basename for new raster maps) required together with
+# the name of the output strds
+T_BASENAME_MODULES_LIST = [
+    "t.rast3d.algebra",
+    "t.rast3d.extract",
+    "t.rast3d.mapcalc",
+    "t.rast.accdetect",
+    "t.rast.accumulate",
+    "t.rast.aggregate.ds",
+    "t.rast.aggregate",
+    "t.rast.algebra",
+    "t.rast.contour",
+    "t.rast.extract",
+    "t.rast.gapfill",
+    "t.rast.import",
+    "t.rast.mapcalc",
+    "t.rast.neighbors",
+    "t.rast.ndvi",
+    "t.rast.to.vect",
+]
 # standard openeo process descriptions
 PROCESS_DESCRIPTION_DICT = {}
 PROCESS_DICT = {}
@@ -315,7 +336,9 @@ def process_node_to_actinia_process_chain(node: Node) -> Tuple[list, list]:
 
 
 def openeo_to_actinia(node: Node) -> Tuple[list, list]:
-    """Generic translator of openeo to actinia
+    """Generic translator of openeo to actinia for actinia modules that
+       have been translated to openeo processes with 
+       register_processes()
 
     :param node: The process node
     :return: (output_objects, actinia_process_list)
@@ -462,6 +485,10 @@ def openeo_to_actinia(node: Node) -> Tuple[list, list]:
                 pc["inputs"].append(param)
                 output_objects.append(output_object)
                 node.add_output(output_object=output_object)
+        if module_name in T_BASENAME_MODULES_LIST:
+            param = {"param": "basename",
+                     "value": output_object.grass_name()}
+            pc["inputs"].append(param)
 
     process_list.append(pc)
 

--- a/src/openeo_grass_gis_driver/actinia_processing/base.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/base.py
@@ -337,7 +337,7 @@ def process_node_to_actinia_process_chain(node: Node) -> Tuple[list, list]:
 
 def openeo_to_actinia(node: Node) -> Tuple[list, list]:
     """Generic translator of openeo to actinia for actinia modules that
-       have been translated to openeo processes with 
+       have been translated to openeo processes with
        register_processes()
 
     :param node: The process node

--- a/src/openeo_grass_gis_driver/register_actinia_processes.py
+++ b/src/openeo_grass_gis_driver/register_actinia_processes.py
@@ -3,7 +3,8 @@ from openeo_grass_gis_driver.actinia_processing.config import Config \
     as ActiniaConfig
 from openeo_grass_gis_driver.actinia_processing.base import \
     ACTINIA_OPENEO_PROCESS_DESCRIPTION_DICT, \
-    OPENEO_ACTINIA_ID_DICT
+    OPENEO_ACTINIA_ID_DICT, \
+    T_BASENAME_MODULES_LIST
 from openeo_grass_gis_driver.actinia_processing.actinia_interface import \
     ActiniaInterface
 
@@ -27,6 +28,17 @@ def register_processes():
         print("Registering modules...")
         for module in modules:
             # convert grass module names to openeo process names
+            # special treatment for GRASS modules in
+            # T_BASENAME_MODULES_LIST
+            if module["id"] in T_BASENAME_MODULES_LIST:
+                if "parameters" in module:
+                    module["parameters"] = [
+                        i for i in module["parameters"] if i["name"] != "basename"
+                    ]
+                if "returns" in module:
+                    module["returns"] = [
+                        i for i in module["returns"] if i["name"] != "basename"
+                    ]
             process = module["id"].replace('.', '_')
             actiniaid = module["id"]
             if "parameters" in module:
@@ -49,6 +61,10 @@ def register_processes():
                 # create "pseudo" module for every output:
                 for returns in module['returns']:
                     pm = dict(module)
+                    pm["links"] = dict()
+                    pm["links"]["about"] = (
+                        "https://grass.osgeo.org/grass80/manuals/%s.html" % pm["id"]
+                    )
                     pm['returns'] = returns
                     process = "%s_%s" % (
                         pm['id'].replace('.', '_'), returns['name'])
@@ -60,6 +76,10 @@ def register_processes():
                     }
             else:
                 # if no output, assign empty object
+                module["links"] = dict()
+                module["links"]["about"] = (
+                    "https://grass.osgeo.org/grass80/manuals/%s.html" % module["id"]
+                )
                 module['returns'] = {}
                 module["id"] = process
                 OPENEO_ACTINIA_ID_DICT[process] = {"id": actiniaid}

--- a/src/openeo_grass_gis_driver/utils/process_graph_examples_v10.py
+++ b/src/openeo_grass_gis_driver/utils/process_graph_examples_v10.py
@@ -810,32 +810,33 @@ OPENEO_EXAMPLE_1 = {
 }
 
 ACTINIA_PROCESS = {
-    "title": "Get a raster layer",
-    "description": "This process is the source for a raster layer",
+    "title": "test actinia modules",
+    "description": "test t.rast.series",
     "process": {
         "process_graph": {
-            "get_elevation_data": {
+            "get_strds_1": {
                 "process_id": "load_collection",
                 "arguments": {
-                    "id": "nc_spm_08.PERMANENT.raster.elevation",
+                    "id": "nc_spm_08.modis_lst.strds.LST_Day_monthly",
                     "spatial_extent": {
-                        "west": 630000,
-                        "east": 645000,
-                        "north": 228500,
-                        "south": 215000,
+                        "west": -448265,
+                        "east": 1550934,
+                        "north": 760180,
+                        "south": -415819,
                         "crs": "+proj=lcc +lat_1=36.16666666666666 +lat_2=34.33333333333334 +lat_0=33.75 +lon_0=-79 +x_0=609601.22 +y_0=0 +no_defs +a=6378137 +rf=298.257222101 +towgs84=0.000,0.000,0.000 +type=crs  +to_meter=1"
                     },
                     "temporal_extent": [
-                        "2018-01-01",
-                        "2019-01-01"
+                        "2016-06-01",
+                        "2017-01-01"
                     ]
                 }
             },
-            "compute_slope": {
-                "process_id": "r_slope_aspect_slope",
+            "t_rast_series_1": {
+                "result": True,
+                "process_id": "t_rast_series_output",
                 "arguments": {
-                    "elevation": {"from_node": "get_elevation_data"},
-                    "e": True
+                    "input": {"from_node": "get_strds_1"},
+                    "method": "average"
                 }
             }
         }


### PR DESCRIPTION
Some GRASS `t.rast.*` modules have two required output options, `output` for the strds and `basename` for the new raster maps. With this PR, `basename` will be set automatically in the openeo GRASS driver for selected GRASS modules, fulfilling the openeo requirement of only one output per process. 