### PR TITLE
Integrate actinia stac collections

### DIFF
--- a/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
@@ -358,3 +358,28 @@ class ActiniaInterface(object):
             data = ret
 
         return r.status_code, data
+
+    def get_stac_collections(self) -> Tuple[int, dict]:
+        url = "%(base)s/stac/collections" % {
+                 "base": self.base_url}
+        r = requests.get(url=url, auth=self.auth)
+        data = r.text
+
+        if r.status_code == 200:
+            ret = r.json()
+            data = ret
+
+        return r.status_code, data
+
+    def get_stac_collection(self, name: str) -> Tuple[int, dict]:
+        url = "%(base)s/stac/collections/%(name)s" % {
+                 "base": self.base_url,
+                 "name": name}
+        r = requests.get(url=url, auth=self.auth)
+        data = r.text
+
+        if r.status_code == 200:
+            ret = r.json()
+            data = ret
+
+        return r.status_code, data

--- a/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
@@ -367,7 +367,6 @@ class ActiniaInterface(object):
 
         if r.status_code == 200:
             data = r.json()
-            data = ret
 
         return r.status_code, data
 

--- a/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
@@ -378,6 +378,6 @@ class ActiniaInterface(object):
         data = r.text
 
         if r.status_code == 200:
-            ret = r.json()
+            data = r.json()
 
         return r.status_code, data

--- a/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
@@ -366,7 +366,7 @@ class ActiniaInterface(object):
         data = r.text
 
         if r.status_code == 200:
-            ret = r.json()
+            data = r.json()
             data = ret
 
         return r.status_code, data

--- a/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/actinia_interface.py
@@ -380,6 +380,5 @@ class ActiniaInterface(object):
 
         if r.status_code == 200:
             ret = r.json()
-            data = ret
 
         return r.status_code, data

--- a/src/openeo_grass_gis_driver/collection_information.py
+++ b/src/openeo_grass_gis_driver/collection_information.py
@@ -139,7 +139,7 @@ class CollectionInformationResource(Resource):
             # Not using CollectionInformation model here for now
             # as valid STAC collections comply.
             # Using it here might omit some properties
-            # which are not modeled in this backend (e.g. assets)
+            # which are not modelled in this backend (e.g. assets)
             return make_response(collection, 200)
 
         status_code, layer_data = self.iface.layer_info(layer_name=name)

--- a/src/openeo_grass_gis_driver/collection_information.py
+++ b/src/openeo_grass_gis_driver/collection_information.py
@@ -123,6 +123,25 @@ class CollectionInformationResource(Resource):
         location, mapset, datatype, layer = self.iface.layer_def_to_components(
             name)
 
+        if location == "stac":
+            status_code, collection = self.iface.get_stac_collection(name=name)
+            if status_code != 200:
+                return make_response(
+                    jsonify(
+                        {
+                            "id": "12345678",
+                            "code": "Internal",
+                            "message": "Server error: %s" %
+                            (name),
+                            "links": {}}),
+                    500)
+
+            # Not using CollectionInformation model here for now
+            # as valid STAC collections comply.
+            # Using it here might omit some properties
+            # which are not modeled in this backend (e.g. assets)
+            return make_response(collection, 200)
+
         status_code, layer_data = self.iface.layer_info(layer_name=name)
         if status_code != 200:
             return make_response(
@@ -166,7 +185,7 @@ class CollectionInformationResource(Resource):
         },
             "y": {
             "type": "spatial",
-            "axis": "x"
+            "axis": "y"
         },
         }
         platform = "unknown"

--- a/src/openeo_grass_gis_driver/collections.py
+++ b/src/openeo_grass_gis_driver/collections.py
@@ -7,7 +7,6 @@ from openeo_grass_gis_driver.actinia_processing.actinia_interface import \
 from openeo_grass_gis_driver.actinia_processing.config import Config
 from openeo_grass_gis_driver.models.collection_schemas import \
      Collection, CollectionEntry
-# from openeo_grass_gis_driver.utils.logging import log
 
 
 __license__ = "Apache License, Version 2.0"
@@ -94,7 +93,6 @@ class Collections(Resource):
             # Additionally check for STAC collections registered in actinia
             status_code, stac_collections = self.iface.get_stac_collections()
             if status_code != 200:
-                # log.warning("Couldn't get STAC collections from actinia")
                 stac_collections = []
 
             for i in stac_collections['collections']:

--- a/src/openeo_grass_gis_driver/collections.py
+++ b/src/openeo_grass_gis_driver/collections.py
@@ -7,6 +7,8 @@ from openeo_grass_gis_driver.actinia_processing.actinia_interface import \
 from openeo_grass_gis_driver.actinia_processing.config import Config
 from openeo_grass_gis_driver.models.collection_schemas import \
      Collection, CollectionEntry
+# from openeo_grass_gis_driver.utils.logging import log
+
 
 __license__ = "Apache License, Version 2.0"
 __author__ = "Sören Gebbert, Carmen Tawalika"
@@ -88,6 +90,34 @@ class Collections(Resource):
                     #                      "mapset path: /%s/%s" % (
                     #                       location, mapset)))
                     #     COLLECTIONS_LIST.append(ds)
+
+            # Additionally check for STAC collections registered in actinia
+            status_code, stac_collections = self.iface.get_stac_collections()
+            if status_code != 200:
+                # log.warning("Couldn't get STAC collections from actinia")
+                stac_collections = []
+
+            for i in stac_collections['collections']:
+                try:
+                    title = i['title']
+                except Exception:
+                    title = i['id']
+                try:
+                    license = i['license']
+                except Exception:
+                    license = "proprietary"
+                try:
+                    description = i['description']
+                except Exception:
+                    description = "STAC collection registered in actinia"
+
+                ds = CollectionEntry(
+                    id=i['id'],
+                    title=title,
+                    license=license,
+                    description=description
+                )
+                COLLECTIONS_LIST.append(ds)
 
         c = Collection(collections=COLLECTIONS_LIST)
         return c.as_response(http_status=200)

--- a/src/openeo_grass_gis_driver/models/collection_schemas.py
+++ b/src/openeo_grass_gis_driver/models/collection_schemas.py
@@ -716,7 +716,7 @@ class CollectionEntry(JsonableObject):
                 },
                 "y": {
                 "type": "spatial",
-                "axis": "x"
+                "axis": "y"
                 },
                 }
         self.cube___dimensions = dimensions


### PR DESCRIPTION
With the implementation of [actinia-stac-plugin](https://github.com/mundialis/actinia-stac-plugin) and this PR, it is now possible to also request STAC collections registered in actinia. They will be integrated in the collections list and can be requested by id.
For this feature to work, actinia needs to be installed with the actinia-stac-plugin. If it is not installed, the STAC collections are simply not included in the `/collections` response (like before).

"Normal" STRDS:
![strds](https://user-images.githubusercontent.com/8308401/142254554-6ee32e71-b19f-43d4-a0df-86605773e2d0.jpeg)

STAC collection:
![stac](https://user-images.githubusercontent.com/8308401/142254550-d8341e58-0e70-42ab-8d6c-12e57d006417.jpeg)

There are some differences in attributes but I decided to not use the `CollectionInformation`. See more detailed explanation why in comment in `src/openeo_grass_gis_driver/collection_information.py `