### PR TITLE
Introduce logger

### DIFF
--- a/src/openeo_grass_gis_driver/actinia_processing/config.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/config.py
@@ -3,6 +3,8 @@ import os
 import configparser
 from pathlib import Path
 
+from openeo_grass_gis_driver.utils.logging import log
+
 __license__ = "Apache License, Version 2.0"
 __author__ = "Sören Gebbert, Carmen Tawalika"
 __copyright__ = "Copyright 2018-2021, Sören Gebbert, mundialis"
@@ -46,11 +48,11 @@ class Configfile:
         """
 
         config = configparser.ConfigParser()
-        print("Loading config files: " + str(CONFIG_FILES) + " ...")
+        log.info("Loading config files: " + str(CONFIG_FILES) + " ...")
         config.read(CONFIG_FILES)
 
         if len(config) <= 1:
-            print("Could not find any config file, using default values.")
+            log.debug("Could not find any config file, using default values.")
             return
 
         # commented out due to

--- a/src/openeo_grass_gis_driver/collections.py
+++ b/src/openeo_grass_gis_driver/collections.py
@@ -7,6 +7,7 @@ from openeo_grass_gis_driver.actinia_processing.actinia_interface import \
 from openeo_grass_gis_driver.actinia_processing.config import Config
 from openeo_grass_gis_driver.models.collection_schemas import \
      Collection, CollectionEntry
+from openeo_grass_gis_driver.utils.logging import log
 
 
 __license__ = "Apache License, Version 2.0"
@@ -93,6 +94,7 @@ class Collections(Resource):
             # Additionally check for STAC collections registered in actinia
             status_code, stac_collections = self.iface.get_stac_collections()
             if status_code != 200:
+                log.warning("Couldn't get STAC collections from actinia")
                 stac_collections = []
 
             for i in stac_collections['collections']:

--- a/src/openeo_grass_gis_driver/register_actinia_processes.py
+++ b/src/openeo_grass_gis_driver/register_actinia_processes.py
@@ -86,4 +86,4 @@ def register_processes():
         log.info("... successfully registered modules!")
 
     else:
-        log.info('... error registering modules!')
+        log.error('... error registering modules!')

--- a/src/openeo_grass_gis_driver/register_actinia_processes.py
+++ b/src/openeo_grass_gis_driver/register_actinia_processes.py
@@ -7,6 +7,7 @@ from openeo_grass_gis_driver.actinia_processing.base import \
     T_BASENAME_MODULES_LIST
 from openeo_grass_gis_driver.actinia_processing.actinia_interface import \
     ActiniaInterface
+from openeo_grass_gis_driver.utils.logging import log
 
 
 __license__ = "Apache License, Version 2.0"
@@ -19,13 +20,10 @@ def register_processes():
 
     iface = ActiniaInterface()
     iface.set_auth(ActiniaConfig.USER, ActiniaConfig.PASSWORD)
-    # TODO: add logger
-    print("Requesting modules from %s..." % ActiniaConfig.HOST)
+    log.info("Requesting modules from %s..." % ActiniaConfig.HOST)
     status_code, modules = iface.list_modules()
 
     if status_code == 200:
-        # TODO: add logger
-        print("Registering modules...")
         for module in modules:
             # convert grass module names to openeo process names
             # special treatment for GRASS modules in
@@ -85,8 +83,7 @@ def register_processes():
                 OPENEO_ACTINIA_ID_DICT[process] = {"id": actiniaid}
                 ACTINIA_OPENEO_PROCESS_DESCRIPTION_DICT[process] = module
 
-        # TODO: add logger
-        print("... successfully registered modules!")
+        log.info("... successfully registered modules!")
 
     else:
-        print('... error registering modules!')
+        log.info('... error registering modules!')

--- a/src/openeo_grass_gis_driver/utils/logging.py
+++ b/src/openeo_grass_gis_driver/utils/logging.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+import logging
+from datetime import datetime
+from logging import FileHandler
+
+from colorlog import ColoredFormatter
+from pythonjsonlogger import jsonlogger
+
+__license__ = "Apache License, Version 2.0"
+__author__ = "Carmen Tawalika"
+__copyright__ = "Copyright 2019-2021, mundialis"
+__maintainer__ = "Carmen Tawalika"
+
+
+# TODO make configurable
+class LogConfig(object):
+    def __init__(self):
+        self.logfile = "/openeo-grassgis-driver.log"
+        self.level = "INFO"
+        self.type = "json"
+
+
+LOGCONFIG = LogConfig()
+
+log = logging.getLogger('openeo-grass-gis-driver')
+werkzeugLog = logging.getLogger('werkzeug')
+gunicornLog = logging.getLogger('gunicorn')
+
+
+def setLogFormat(veto=None):
+    # "veto" is used for fileformat, so "type=json" is only applied to stdout
+    logformat = ""
+    if LOGCONFIG.type == 'json' and not veto:
+        logformat = CustomJsonFormatter('%(time) %(level) %(component)'
+                                        '%(module) %(message) %(pathname)'
+                                        '%(lineno) %(processName)'
+                                        '%(threadName)')
+    else:
+        logformat = ColoredFormatter(
+            '%(log_color)s[%(asctime)s] %(levelname)-10s: %(name)s.%(module)-'
+            '10s -%(message)s [in %(pathname)s:%(lineno)d]%(reset)s'
+        )
+    return logformat
+
+
+def setLogHandler(logger, type, format):
+    if type == 'stdout':
+        handler = logging.StreamHandler()
+    elif type == 'file':
+        # For readability, json is never written to file
+        handler = FileHandler(LOGCONFIG.logfile)
+    handler.setFormatter(format)
+    logger.addHandler(handler)
+
+
+class CustomJsonFormatter(jsonlogger.JsonFormatter):
+    def add_fields(self, log_record, record, message_dict):
+        super(CustomJsonFormatter, self).add_fields(
+            log_record, record, message_dict)
+
+        # (Pdb) dir(record)
+        # ... 'args', 'created', 'exc_info', 'exc_text', 'filename', 'funcName'
+        # ,'getMessage', 'levelname', 'levelno', 'lineno', 'message', 'module',
+        # 'msecs', 'msg', 'name', 'pathname', 'process', 'processName',
+        # 'relativeCreated', 'stack_info', 'thread', 'threadName']
+
+        now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        log_record['time'] = now
+        log_record['level'] = record.levelname
+        log_record['component'] = record.name
+
+
+def createLogger():
+    # create logger, set level and define format
+    log.setLevel(getattr(logging, LOGCONFIG.level))
+    fileformat = setLogFormat('veto')
+    stdoutformat = setLogFormat()
+    setLogHandler(log, 'file', fileformat)
+    setLogHandler(log, 'stdout', stdoutformat)
+
+
+def createWerkzeugLogger():
+    werkzeugLog.setLevel(getattr(logging, LOGCONFIG.level))
+    fileformat = setLogFormat('veto')
+    stdoutformat = setLogFormat()
+    setLogHandler(werkzeugLog, 'file', fileformat)
+    setLogHandler(werkzeugLog, 'stdout', stdoutformat)
+
+
+def createGunicornLogger():
+    gunicornLog.setLevel(getattr(logging, LOGCONFIG.level))
+    fileformat = setLogFormat('veto')
+    stdoutformat = setLogFormat()
+    setLogHandler(gunicornLog, 'file', fileformat)
+    setLogHandler(gunicornLog, 'stdout', stdoutformat)
+    # gunicorn already has a lot of children logger, e.g gunicorn.http,
+    # gunicorn.access. These lines deactivate their default handlers.
+    for name in logging.root.manager.loggerDict:
+        if "gunicorn." in name:
+            logging.getLogger(name).propagate = True
+            logging.getLogger(name).handlers = []
+
+
+createLogger()
+createWerkzeugLogger()
+createGunicornLogger()


### PR DESCRIPTION
This PR introduces a logger. By default it prints logs to STDOUT in JSON format. It is not configurable yet but if this is needed it can be done in a separate PR.

One example log is integrated in `collections.py`. The line `log.warning("Couldn't get STAC collections from actinia")` will look like the following in the STDOUT log output:

```
{"time": "2021-11-19T16:50:00.811279Z", "level": "WARNING", "component": "openeo-grass-gis-driver", "module": "collections", "message": "Couldn't get STAC collections from actinia", "pathname": "/src/openeo_grass_gis_driver/src/openeo_grass_gis_driver/collections.py", "lineno": 97, "processName": "MainProcess", "threadName": "Thread-10"}
```

Depending on deployment, simple `print` statements are not visible in STDOUT/collected for docker logs. These `print` statements were adjusted in this PR as well.
This also helps for integration with logging tools like e.g. Kibana when deployed in a cloud environment.