### PR TITLE
Enhance dev setup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
             "dockerServerReadyAction": {
               "action": "openExternally",
               "pattern": "Running on (https?://\\S+|[0-9]+)",
-              "uriFormat": "%s://localhost:%s/api/v1.0/collections"
+              "uriFormat": "%s://localhost:%s/api/v1.0/processes"
             }
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,20 +22,25 @@
 				"args": [
 					"run",
 					"--no-debugger",
-					// "--no-reload",
 					"--host",
 					"0.0.0.0",
 					"--port",
 					"5000"
 				],
 				"module": "flask"
-				// "file": "dev.py"
 			},
 			"dockerRun": {
 				"remove": true,
-				// network host is needed when connecting to a local actinia
-				// while not using docker-compose network
-				"network": "host",
+				// When connecting to a local actinia, the following network
+				// can be used. The network must exist before and can be
+				// created with vscode debugger inside actinia_core.
+				// "network": "docker_actinia-dev",
+				"ports": [
+				  {
+					"containerPort": 5000,
+					"hostPort": 5000
+				  }
+				],
 				"volumes": [{
 					"localPath": "${workspaceFolder}",
 					"containerPath": "/src/openeo_grass_gis_driver",

--- a/config/sample.ini
+++ b/config/sample.ini
@@ -3,3 +3,8 @@ HOST = https://actinia-dev.mundialis.de
 PORT = 443
 USER = openeo
 PASSWORD = EeMob0la
+
+# HOST = http://172.18.0.11
+# PORT = 8088
+# USER = actinia-gdi
+# PASSWORD = actinia-gdi


### PR DESCRIPTION
This PR enhances the local dev setup when developing together with a local actinia-core instance.
As actinia-core also has a dev setup with vscode, this PR adds the option to use the same docker network as actinia to be able to connect to it. In this case, the network must exist before which is the case when debugger with vscode for actinia-core was started before.

Related to https://github.com/mundialis/actinia_core/pull/288