### PR TITLE
openeo GRASS driver: fix temporal filter, fix extents

### DIFF
--- a/src/openeo_grass_gis_driver/actinia_processing/filter_temporal_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/filter_temporal_process.py
@@ -128,23 +128,30 @@ def create__process_chain_entry(
     """
 
     start_time = start_time.replace('T', ' ')
-    end_time = end_time.replace('T', ' ')
-
-    # Get info about the time series to extract its resolution settings and
-    # bbox
     rn = randint(0, 1000000)
 
-    # end_time can be null, and we can not find out if end_time is set because
-    # the input does not exist yet
-    pc = {"id": "t_rast_extract_%i" % rn,
-          "module": "t.rast.extract",
-          "inputs": [{"param": "input", "value": input_object.grass_name()},
-                     {"param": "where", "value": "start_time >= '%(start)s' "
-                      "AND start_time <= '%(end)s'" % {"start": start_time, "end": end_time}},
-                     {"param": "output", "value": output_object.grass_name()},
-                     {"param": "expression", "value": "1.0 * %s" % input_object.name},
-                     {"param": "basename", "value": output_object.name},
-                     {"param": "suffix", "value": "num"}]}
+    # end_time can be null, use only start_time for filtering
+    if end_time and len(end_time) > 0:
+        end_time = end_time.replace('T', ' ')
+
+        pc = {"id": "t_rast_extract_%i" % rn,
+              "module": "t.rast.extract",
+              "inputs": [{"param": "input", "value": input_object.grass_name()},
+                         {"param": "where", "value": "start_time >= '%(start)s' "
+                          "AND start_time < '%(end)s'" % {"start": start_time, "end": end_time}},
+                         {"param": "output", "value": output_object.grass_name()},
+                         {"param": "expression", "value": "1.0 * %s" % input_object.name},
+                         {"param": "basename", "value": output_object.name},
+                         {"param": "suffix", "value": "num"}]}
+    else:
+        pc = {"id": "t_rast_extract_%i" % rn,
+              "module": "t.rast.extract",
+              "inputs": [{"param": "input", "value": input_object.grass_name()},
+                         {"param": "where", "value": "start_time >= '%(start)s'" % {"start": start_time}},
+                         {"param": "output", "value": output_object.grass_name()},
+                         {"param": "expression", "value": "1.0 * %s" % input_object.name},
+                         {"param": "basename", "value": output_object.name},
+                         {"param": "suffix", "value": "num"}]}
 
     return pc
 

--- a/src/openeo_grass_gis_driver/actinia_processing/load_collection_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/load_collection_process.py
@@ -344,10 +344,13 @@ def create_process_chain_entry(input_object: DataObject,
         wherestring = ""
         if temporal_extent:
             start_time = temporal_extent[0].replace('T', ' ')
-            end_time = temporal_extent[1].replace('T', ' ')
+            if len(temporal_extent) > 1:
+                end_time = temporal_extent[1].replace('T', ' ')
+                wherestring = "start_time >= '%(start)s' AND start_time < '%(end)s'" % {
+                                                "start": start_time, "end": end_time}
             # end_time can be null, use only start_time for filtering
-            wherestring = "start_time >= '%(start)s' AND start_time <= '%(end)s'" % {
-                                            "start": start_time, "end": end_time}
+            else:
+                wherestring = "start_time >= '%(start)s'" % {"start": start_time}
             if bands:
                 wherestring = wherestring + " AND "
         if bands:

--- a/src/openeo_grass_gis_driver/collection_information.py
+++ b/src/openeo_grass_gis_driver/collection_information.py
@@ -181,11 +181,15 @@ class CollectionInformationResource(Resource):
         bands = []
         dimensions = {"x": {
             "type": "spatial",
-            "axis": "x"
+            "axis": "x",
+            "extent": [layer_data["west"], layer_data["east"]],
+            "reference_system": mapset_info["projection"]
         },
             "y": {
             "type": "spatial",
-            "axis": "y"
+            "axis": "y",
+            "extent": [layer_data["south"], layer_data["north"]],
+            "reference_system": mapset_info["projection"]
         },
         }
         platform = "unknown"

--- a/src/openeo_grass_gis_driver/jobs_job_id.py
+++ b/src/openeo_grass_gis_driver/jobs_job_id.py
@@ -3,6 +3,7 @@ import traceback
 from uuid import uuid4
 import sys
 from flask import make_response, request
+from openeo_grass_gis_driver.capabilities import CAPABILITIES
 from openeo_grass_gis_driver.actinia_processing.actinia_interface import \
      ActiniaInterface
 from openeo_grass_gis_driver.actinia_processing.config import \
@@ -13,6 +14,7 @@ from openeo_grass_gis_driver.models.error_schemas import ErrorSchema
 from openeo_grass_gis_driver.models.job_schemas import JobInformation
 from openeo_grass_gis_driver.jobs import check_job
 from openeo_grass_gis_driver.authentication import ResourceBase
+from openeo_grass_gis_driver.models.schema_base import EoLink
 
 __license__ = "Apache License, Version 2.0"
 __author__ = "Sören Gebbert"

--- a/src/openeo_grass_gis_driver/jobs_job_id_results.py
+++ b/src/openeo_grass_gis_driver/jobs_job_id_results.py
@@ -197,6 +197,13 @@ class JobsJobIdResults(ResourceBase):
                 actinia_id = self.actinia_job_db[job_id]
                 code, job_info = self.iface.delete_resource(
                     resource_id=actinia_id)
+                del self.actinia_job_db[job_id]
+            
+            job: JobInformation = self.job_db[job_id]
+            job.status = "cancelled"
+            job.updated = str(datetime.now().isoformat())
+
+            self.job_db[job_id] = job
 
             return make_response(
                 "The job has been successfully cancelled", 204)

--- a/src/openeo_grass_gis_driver/jobs_job_id_results.py
+++ b/src/openeo_grass_gis_driver/jobs_job_id_results.py
@@ -198,7 +198,7 @@ class JobsJobIdResults(ResourceBase):
                 code, job_info = self.iface.delete_resource(
                     resource_id=actinia_id)
                 del self.actinia_job_db[job_id]
-            
+
             job: JobInformation = self.job_db[job_id]
             job.status = "cancelled"
             job.updated = str(datetime.now().isoformat())


### PR DESCRIPTION
 * temporal filters are left-closed intervals
 * report extents for spatial dimensions in `cube:dimensions`
 * do not report previous status, but check current status for endpoint `jobs/{job_id}`
 * delete actinia resources when cancelling or deleting a job 