### PR TITLE
add support for local external collections

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,7 +12,6 @@ per-file-ignores =
     ./src/openeo_grass_gis_driver/models/collection_schemas.py: W605, E501
     ./src/openeo_grass_gis_driver/models/job_schemas.py: W605, E501
     ./src/openeo_grass_gis_driver/models/service_schemas.py: W605
-    ./src/openeo_grass_gis_driver/collection_information.py: E501
     ./src/openeo_grass_gis_driver/local_collections.py: E501
     ./src/openeo_grass_gis_driver/jobs_job_id.py: E501
     ./src/openeo_grass_gis_driver/jobs_job_id_estimate.py: E501

--- a/.flake8
+++ b/.flake8
@@ -12,6 +12,7 @@ per-file-ignores =
     ./src/openeo_grass_gis_driver/models/collection_schemas.py: W605, E501
     ./src/openeo_grass_gis_driver/models/job_schemas.py: W605, E501
     ./src/openeo_grass_gis_driver/models/service_schemas.py: W605
+    ./src/openeo_grass_gis_driver/collection_information.py: E501
     ./src/openeo_grass_gis_driver/local_collections.py: E501
     ./src/openeo_grass_gis_driver/jobs_job_id.py: E501
     ./src/openeo_grass_gis_driver/jobs_job_id_estimate.py: E501

--- a/.flake8
+++ b/.flake8
@@ -13,6 +13,7 @@ per-file-ignores =
     ./src/openeo_grass_gis_driver/models/job_schemas.py: W605, E501
     ./src/openeo_grass_gis_driver/models/service_schemas.py: W605
     ./src/openeo_grass_gis_driver/collection_information.py: E501
+    ./src/openeo_grass_gis_driver/collections.py: E501
     ./src/openeo_grass_gis_driver/local_collections.py: E501
     ./src/openeo_grass_gis_driver/jobs_job_id.py: E501
     ./src/openeo_grass_gis_driver/jobs_job_id_estimate.py: E501

--- a/.flake8
+++ b/.flake8
@@ -13,7 +13,6 @@ per-file-ignores =
     ./src/openeo_grass_gis_driver/models/job_schemas.py: W605, E501
     ./src/openeo_grass_gis_driver/models/service_schemas.py: W605
     ./src/openeo_grass_gis_driver/collection_information.py: E501
-    ./src/openeo_grass_gis_driver/collections.py: E501
     ./src/openeo_grass_gis_driver/local_collections.py: E501
     ./src/openeo_grass_gis_driver/jobs_job_id.py: E501
     ./src/openeo_grass_gis_driver/jobs_job_id_estimate.py: E501

--- a/.flake8
+++ b/.flake8
@@ -13,6 +13,7 @@ per-file-ignores =
     ./src/openeo_grass_gis_driver/models/job_schemas.py: W605, E501
     ./src/openeo_grass_gis_driver/models/service_schemas.py: W605
     ./src/openeo_grass_gis_driver/collection_information.py: E501
+    ./src/openeo_grass_gis_driver/local_collections.py: E501
     ./src/openeo_grass_gis_driver/jobs_job_id.py: E501
     ./src/openeo_grass_gis_driver/jobs_job_id_estimate.py: E501
     ./src/openeo_grass_gis_driver/jobs_job_id_logs.py: E501

--- a/src/openeo_grass_gis_driver/actinia_processing/base.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/base.py
@@ -6,8 +6,9 @@ import uuid
 
 # This is the process dictionary that is used to store all processes of
 # the Actinia wrapper
-from openeo_grass_gis_driver.actinia_processing.actinia_interface import \
-     ActiniaInterface
+from openeo_grass_gis_driver.actinia_processing.actinia_interface import (
+    ActiniaInterface,
+)
 
 from openeo_grass_gis_driver.models.process_graph_schemas import ProcessGraph
 
@@ -62,7 +63,13 @@ class GrassDataType(Enum):
     RASTER = "raster"
     VECTOR = "vector"
     STRDS = "strds"
-    STAC = "rastercube"
+    EXTERN = "rastercube"
+
+
+class DataSource(Enum):
+
+    GRASS = "grass"
+    STAC = "stac"
     LOCAL = "gdallocal"
 
 
@@ -72,14 +79,17 @@ class DataObject:
     """
 
     def __init__(
-            self,
-            name: str,
-            datatype: GrassDataType,
-            mapset: str = None,
-            location: str = None):
+        self,
+        name: str,
+        datatype: GrassDataType,
+        datasource: DataSource = DataSource.GRASS,
+        mapset: str = None,
+        location: str = None,
+    ):
 
         self.name = name
         self.datatype = datatype
+        self.datasource = datasource
         self.mapset = mapset
         self.location = location
 
@@ -91,50 +101,67 @@ class DataObject:
     def from_string(name: str):
 
         AI = ActiniaInterface
-        location, mapset, datatype, layer_name = AI.layer_def_to_components(
-            name)
+        location, mapset, datatype, layer_name = AI.layer_def_to_components(name)
 
         if datatype is None:
             raise Exception(f"Invalid collection id <{name}>")
 
-        if GrassDataType.RASTER.value == datatype:
+        datasource = DataSource.GRASS
+        if location == "stac":
+            datasource = DataSource.STAC
+        elif location == "local":
+            datasource = DataSource.LOCAL
+
+        if DataSource.GRASS == datasource and GrassDataType.RASTER.value == datatype:
             return DataObject(
                 name=layer_name,
                 datatype=GrassDataType.RASTER,
+                datasource=datasource,
                 mapset=mapset,
-                location=location)
-        elif GrassDataType.VECTOR.value == datatype:
+                location=location,
+            )
+        elif DataSource.GRASS == datasource and GrassDataType.VECTOR.value == datatype:
             return DataObject(
                 name=layer_name,
                 datatype=GrassDataType.VECTOR,
+                datasource=datasource,
                 mapset=mapset,
-                location=location)
-        elif GrassDataType.STRDS.value == datatype:
+                location=location,
+            )
+        elif DataSource.GRASS == datasource and GrassDataType.STRDS.value == datatype:
             return DataObject(
                 name=layer_name,
                 datatype=GrassDataType.STRDS,
+                datasource=datasource,
                 mapset=mapset,
-                location=location)
-        elif GrassDataType.STAC.value == datatype:
+                location=location,
+            )
+        elif DataSource.STAC == datasource and GrassDataType.EXTERN.value == datatype:
             # location = "stac"
             del AI.PROCESS_LOCATION[location]
             AI.PROCESS_LOCATION["latlong_wgs84"] = "latlong_wgs84"
             return DataObject(
                 name=layer_name,
-                datatype=GrassDataType.STAC,
+                datatype=GrassDataType.EXTERN,
+                datasource=datasource,
                 mapset=mapset,
-                location="latlong_wgs84")
-        elif GrassDataType.LOCAL.value == datatype:
+                location="latlong_wgs84",
+            )
+        elif DataSource.LOCAL == datasource and GrassDataType.EXTERN.value == datatype:
             # location = "local"
             del AI.PROCESS_LOCATION[location]
             AI.PROCESS_LOCATION["latlong_wgs84"] = "latlong_wgs84"
             return DataObject(
                 name=layer_name,
-                datatype=GrassDataType.STAC,
+                datatype=GrassDataType.EXTERN,
+                datasource=datasource,
                 mapset=mapset,
-                location="latlong_wgs84")
+                location="latlong_wgs84",
+            )
 
-        raise Exception(f"Unsupported object type <{datatype}>")
+        raise Exception(
+            f"Unsupported object type <{datatype}> and data source <{datasource.value}>"
+        )
 
     def grass_name(self):
 
@@ -147,28 +174,40 @@ class DataObject:
 
     def is_strds(self):
 
-        return self.datatype == GrassDataType.STRDS
+        return (
+            self.datasource == DataSource.GRASS and self.datatype == GrassDataType.STRDS
+        )
 
     def is_raster(self):
 
-        return self.datatype == GrassDataType.RASTER
+        return (
+            self.datasource == DataSource.GRASS
+            and self.datatype == GrassDataType.RASTER
+        )
 
     def is_vector(self):
 
-        return self.datatype == GrassDataType.VECTOR
+        return (
+            self.datasource == DataSource.GRASS
+            and self.datatype == GrassDataType.VECTOR
+        )
 
     def is_stac(self):
 
-        return self.datatype == GrassDataType.STAC
+        return (
+            self.datasource == DataSource.STAC and self.datatype == GrassDataType.EXTERN
+        )
 
     def is_local(self):
 
-        return self.datatype == GrassDataType.LOCAL
+        return (
+            self.datasource == DataSource.LOCAL
+            and self.datatype == GrassDataType.EXTERN
+        )
 
 
 class Node:
-    """A single node in the process graph
-    """
+    """A single node in the process graph"""
 
     def __init__(self, id, process_description: dict):
 
@@ -188,7 +227,7 @@ class Node:
     def add_output(self, output_object: DataObject):
         self.output_objects.add(output_object)
 
-    def get_parent_by_name(self, parent_name: str) -> Optional['Node']:
+    def get_parent_by_name(self, parent_name: str) -> Optional["Node"]:
         if parent_name in self.parents_dict.keys():
             return self.parents_dict[parent_name]
         return None
@@ -215,8 +254,10 @@ class Node:
         if self.parents_dict:
             parent_names = list(self.parents_dict.keys())
 
-        return (f"Node: {self.id} parent names: {parent_names} parent "
-                f"ids: {parent_ids} child ids: {child_ids}")
+        return (
+            f"Node: {self.id} parent names: {parent_names} parent "
+            f"ids: {parent_ids} child ids: {child_ids}"
+        )
 
     def get_parents_dict(self) -> dict:
 
@@ -237,9 +278,7 @@ class Node:
 
 
 class Graph:
-    """This class represents a process graph
-
-    """
+    """This class represents a process graph"""
 
     def __init__(self, graph_description: Union[Dict, ProcessGraph]):
         """The constructor checks the validity of the provided dictionary
@@ -254,7 +293,8 @@ class Graph:
             self.title: str = graph_description.title
             self.description: str = graph_description.description
             self.build_process_graph_from_description(
-                process_graph=graph_description.process_graph)
+                process_graph=graph_description.process_graph
+            )
         else:
             if "title" not in graph_description:
                 # raise Exception("Title is required in the process graph")
@@ -267,13 +307,16 @@ class Graph:
 
             # graph_description can be a process with process_graph or
             # only a process_graph
-            if "process" not in graph_description and \
-               "process_graph" not in graph_description:
-                raise Exception(
-                    "process_graph is required in the process graph")
+            if (
+                "process" not in graph_description
+                and "process_graph" not in graph_description
+            ):
+                raise Exception("process_graph is required in the process graph")
 
-            if "process" in graph_description and \
-               "process_graph" not in graph_description["process"]:
+            if (
+                "process" in graph_description
+                and "process_graph" not in graph_description["process"]
+            ):
                 raise Exception("process_graph is required in the process")
 
             if "process" in graph_description:
@@ -283,8 +326,7 @@ class Graph:
             self.title: str = graph_description["title"]
             self.description: str = graph_description["description"]
 
-            self.build_process_graph_from_description(
-                process_graph=process_graph)
+            self.build_process_graph_from_description(process_graph=process_graph)
 
     def build_process_graph_from_description(self, process_graph: dict):
         """Build the directed process graph from the graph description
@@ -442,31 +484,30 @@ def openeo_to_actinia(node: Node) -> Tuple[list, list]:
             # warning, error, exception?
             continue
         # check if it is an input object
-        if isinstance(node.arguments[key], dict) and \
-           "from_node" in node.arguments[key]:
+        if isinstance(node.arguments[key], dict) and "from_node" in node.arguments[key]:
             # input option comes from another node in the process graph
             # which output object in the set of output_objects?
-            value = list(
-                node.get_parent_by_name(
-                    parent_name=key).output_objects)[0]
+            value = list(node.get_parent_by_name(parent_name=key).output_objects)[0]
             data_object = value
             # check schema subtype of parameter and compare with
             # datatype of data_object
-            if ao["schema"]["subtype"] == "cell" and \
-                    data_object.datatype != GrassDataType.RASTER:
-                raise Exception(
-                    "Wrong input data type, expecting 'cell'")
-            elif ao["schema"]["subtype"] == "strds" and \
-                    data_object.datatype != GrassDataType.STRDS:
-                raise Exception(
-                    "Wrong input data type, expecting 'strds'")
-            elif ao["schema"]["subtype"] == "vector" and \
-                    data_object.datatype != GrassDataType.VECTOR:
-                raise Exception(
-                    "Wrong input data type, expecting 'vector'")
+            if (
+                ao["schema"]["subtype"] == "cell"
+                and data_object.datatype != GrassDataType.RASTER
+            ):
+                raise Exception("Wrong input data type, expecting 'cell'")
+            elif (
+                ao["schema"]["subtype"] == "strds"
+                and data_object.datatype != GrassDataType.STRDS
+            ):
+                raise Exception("Wrong input data type, expecting 'strds'")
+            elif (
+                ao["schema"]["subtype"] == "vector"
+                and data_object.datatype != GrassDataType.VECTOR
+            ):
+                raise Exception("Wrong input data type, expecting 'vector'")
 
-            param = {"param": key,
-                     "value": data_object.grass_name()}
+            param = {"param": key, "value": data_object.grass_name()}
             pc["inputs"].append(param)
         elif ao["schema"]["type"] == "boolean":
             # flag
@@ -478,8 +519,7 @@ def openeo_to_actinia(node: Node) -> Tuple[list, list]:
         else:
             # option answer, treat as string
             value = node.arguments[key]
-            param = {"param": key,
-                     "value": str(value)}
+            param = {"param": key, "value": str(value)}
             pc["inputs"].append(param)
 
     if pc["flags"] is None:
@@ -487,9 +527,7 @@ def openeo_to_actinia(node: Node) -> Tuple[list, list]:
 
     # TODO: support modules that do not have input maps
     if data_object is None:
-        raise Exception(
-            "No input data object for actinia process '%s'" %
-            module_name)
+        raise Exception("No input data object for actinia process '%s'" % module_name)
 
     # output parameters
     if "returns" in module and openeo_returns is not None:
@@ -516,16 +554,14 @@ def openeo_to_actinia(node: Node) -> Tuple[list, list]:
                 # in order to distinguish between different outputs
                 # of the same module
                 output_object = DataObject(
-                    name=create_output_name(data_object.name, node),
-                    datatype=datatype)
-                param = {"param": key,
-                         "value": output_object.grass_name()}
+                    name=create_output_name(data_object.name, node), datatype=datatype
+                )
+                param = {"param": key, "value": output_object.grass_name()}
                 pc["inputs"].append(param)
                 output_objects.append(output_object)
                 node.add_output(output_object=output_object)
         if module_name in T_BASENAME_MODULES_LIST:
-            param = {"param": "basename",
-                     "value": output_object.name}
+            param = {"param": "basename", "value": output_object.name}
             pc["inputs"].append(param)
 
     process_list.append(pc)
@@ -549,7 +585,7 @@ def create_output_name(input: str, node: Node):
     new_uuid = uuid.uuid4().hex
 
     # shorter version: only uuid + node id
-    node_id = node.id.lower().replace(' ', '_')
+    node_id = node.id.lower().replace(" ", "_")
     output = f"uuid{new_uuid}_{node_id}"
 
     return output

--- a/src/openeo_grass_gis_driver/actinia_processing/base.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/base.py
@@ -63,6 +63,7 @@ class GrassDataType(Enum):
     VECTOR = "vector"
     STRDS = "strds"
     STAC = "rastercube"
+    LOCAL = "gdallocal"
 
 
 class DataObject:
@@ -115,6 +116,18 @@ class DataObject:
                 mapset=mapset,
                 location=location)
         elif GrassDataType.STAC.value == datatype:
+            # location = "stac"
+            del AI.PROCESS_LOCATION[location]
+            AI.PROCESS_LOCATION["latlong_wgs84"] = "latlong_wgs84"
+            return DataObject(
+                name=layer_name,
+                datatype=GrassDataType.STAC,
+                mapset=mapset,
+                location="latlong_wgs84")
+        elif GrassDataType.LOCAL.value == datatype:
+            # location = "local"
+            del AI.PROCESS_LOCATION[location]
+            AI.PROCESS_LOCATION["latlong_wgs84"] = "latlong_wgs84"
             return DataObject(
                 name=layer_name,
                 datatype=GrassDataType.STAC,
@@ -147,6 +160,10 @@ class DataObject:
     def is_stac(self):
 
         return self.datatype == GrassDataType.STAC
+
+    def is_local(self):
+
+        return self.datatype == GrassDataType.LOCAL
 
 
 class Node:

--- a/src/openeo_grass_gis_driver/actinia_processing/config.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/config.py
@@ -37,6 +37,8 @@ class ACTINIA:
     # The database file that stores the actinia jobs
     ACTINIA_JOB_DB = "%s/.actinia_job_db_file.sqlite" % os.environ["HOME"]
     SECRET_KEY = "jaNguzeef4seiv5shahchimoo8teiLah"
+    # path to json files with collection definitions
+    LOCAL_COLLECTIONS = "%s/.openeo_local_collections" % os.environ["HOME"]
 
 
 class Configfile:

--- a/src/openeo_grass_gis_driver/actinia_processing/load_collection_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/load_collection_process.py
@@ -356,8 +356,8 @@ def create_process_chain_entry(
             # TODO: get root path from link in collection information ?
 
             importer = {
-                "id": "t_in_eolab_%i" % rn,
-                "module": "t.in.eolab",
+                "id": "t_in_eoarchive_%i" % rn,
+                "module": "t.in.eoarchive",
                 "inputs": [
                     {"param": "collection", "value": input_object.name()},
                     {"param": "start", "value": temporal_extent[0].split("T")[0]},

--- a/src/openeo_grass_gis_driver/actinia_processing/load_collection_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/load_collection_process.py
@@ -11,6 +11,7 @@ from openeo_grass_gis_driver.actinia_processing.base import (
     PROCESS_DESCRIPTION_DICT,
     Node,
     check_node_parents,
+    GrassDataType,
     DataObject,
     create_output_name,
 )
@@ -483,12 +484,12 @@ def get_process_list(node: Node):
     elif input_object.is_stac():
         output_object = DataObject(
             name=create_output_name(input_object.name, node),
-            datatype=input_object.datatype,
+            datatype=GrassDataType.STRDS,
         )
     elif input_object.is_local():
         output_object = DataObject(
             name=create_output_name(input_object.name, node),
-            datatype=input_object.datatype,
+            datatype=GrassDataType.STRDS,
         )
     else:
         output_object = input_object

--- a/src/openeo_grass_gis_driver/actinia_processing/load_collection_process.py
+++ b/src/openeo_grass_gis_driver/actinia_processing/load_collection_process.py
@@ -2,13 +2,24 @@
 from random import randint
 import json
 
-from openeo_grass_gis_driver.models.process_graph_schemas import \
-     ProcessGraph, ProcessGraphNode
-from openeo_grass_gis_driver.actinia_processing.base import \
-     PROCESS_DICT, PROCESS_DESCRIPTION_DICT, Node, \
-     check_node_parents, DataObject, create_output_name
-from openeo_grass_gis_driver.models.process_schemas import \
-     Parameter, ProcessDescription, ReturnValue, ProcessExample
+from openeo_grass_gis_driver.models.process_graph_schemas import (
+    ProcessGraph,
+    ProcessGraphNode,
+)
+from openeo_grass_gis_driver.actinia_processing.base import (
+    PROCESS_DICT,
+    PROCESS_DESCRIPTION_DICT,
+    Node,
+    check_node_parents,
+    DataObject,
+    create_output_name,
+)
+from openeo_grass_gis_driver.models.process_schemas import (
+    Parameter,
+    ProcessDescription,
+    ReturnValue,
+    ProcessExample,
+)
 
 __license__ = "Apache License, Version 2.0"
 __author__ = "Markus Metz"
@@ -32,134 +43,101 @@ def create_process_description():
             "examples": [
                 "nc_spm_08.landsat.raster.lsat5_1987_10",
                 "nc_spm_08.PERMANENT.vector.lakes",
-                "ECAD.PERMANENT.strds.temperature_1950_2017_yearly"]})
-    p_spatial = Parameter(description="Limits the data to load from the collection to the specified bounding box or polygons.\n\n"
-                          "The coordinate reference system of the bounding box must be specified as [EPSG](http://www.epsg.org) code or [PROJ](https://proj4.org) definition.",
-                          schema=[{
-                           "title": "Bounding Box",
-                           "type": "object",
-                           "subtype": "bounding-box",
-                           "required": [
-                                  "west",
-                                  "south",
-                                  "east",
-                                  "north"
-                                  ],
-                           "properties": {
-                                  "west": {
-                                    "description": "West (lower left corner, coordinate axis 1).",
-                                    "type": "number"
-                                  },
-                                  "south": {
-                                    "description": "South (lower left corner, coordinate axis 2).",
-                                    "type": "number"
-                                  },
-                                  "east": {
-                                    "description": "East (upper right corner, coordinate axis 1).",
-                                    "type": "number"
-                                  },
-                                  "north": {
-                                    "description": "North (upper right corner, coordinate axis 2).",
-                                    "type": "number"
-                                  },
-                                  "base": {
-                                    "description": "Base (optional, lower left corner, coordinate axis 3).",
-                                    "type": [
-                                      "number",
-                                      "null"
-                                    ],
-                                    "default": "null"
-                                  },
-                                  "height": {
-                                    "description": "Height (optional, upper right corner, coordinate axis 3).",
-                                    "type": [
-                                      "number",
-                                      "null"
-                                    ],
-                                    "default": "null"
-                                  },
-                                  "crs": {
-                                    "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
-                                    "schema": {
-                                      "anyOf": [
-                                        {
-                                          "title": "EPSG Code",
-                                          "type": "integer",
-                                          "subtype": "epsg-code",
-                                          "examples": [
-                                            7099
-                                          ]
-                                        },
-                                        {
-                                          "title": "WKT2",
-                                          "type": "string",
-                                          "subtype": "wkt2-definition"
-                                        },
-                                        {
-                                          "title": "PROJ definition",
-                                          "type": "string",
-                                          "subtype": "proj-definition",
-                                          "deprecated": "true"
-                                        }
-                                      ],
-                                      "default": 4326
-                                    }
-                                  }
-                                }
-                           },
-                           {
-                           "title": "GeoJSON",
-                           "type": "object",
-                           "subtype": "geojson"
-                           }
-                          ],
-                          optional=False)
-    p_temporal = Parameter(description="Limits the data to load from the collection to the specified left-closed temporal interval. Applies to all temporal dimensions if there are multiple of them. Left-closed temporal interval, i.e. an array with exactly two elements:\n\n1. The first element is the start of the date and/or time interval. The specified instance in time is **included** in the interval.\n2. The second element is the end of the date and/or time interval. The specified instance in time is **excluded** from the interval.\n\nThe specified temporal strings follow [RFC 3339](https://tools.ietf.org/html/rfc3339). Although [RFC 3339 prohibits the hour to be '24'](https://tools.ietf.org/html/rfc3339#section-5.7), **this process allows the value '24' for the hour** of an end time in order to make it possible that left-closed time intervals can fully cover the day.\n\nAlso supports open intervals by setting one of the boundaries to `null`, but never both.",
-                           schema={"type": "array",
-                                   "subtype": "temporal-interval",
-                                   "minItems": 2,
-                                   "maxItems": 2,
-                                   "items": {
-                                     "anyOf": [{
-                                      "type": "string",
-                                      "format": "date-time",
-                                      "subtype": "date-time"
-                                      },
-                                      {
-                                      "type": "string",
-                                      "format": "date",
-                                      "subtype": "date"
-                                      },
-                                      {
-                                      "type": "string",
-                                      "subtype": "time"
-                                      },
-                                      {
-                                      "type": "null"
-                                      }
-                                      ]
-                                      },
-                                   "examples": [
-                                      [
-                                        "2015-01-01",
-                                        "2016-01-01"
-                                      ],
-                                      [
-                                        "12:00:00Z",
-                                        "24:00:00Z"
-                                      ]
-                                   ]
-                                   },
-                           optional=False)
+                "ECAD.PERMANENT.strds.temperature_1950_2017_yearly",
+            ],
+        },
+    )
+    p_spatial = Parameter(
+        description="Limits the data to load from the collection to the specified bounding box or polygons.\n\n"
+        "The coordinate reference system of the bounding box must be specified as [EPSG](http://www.epsg.org) code or [PROJ](https://proj4.org) definition.",
+        schema=[
+            {
+                "title": "Bounding Box",
+                "type": "object",
+                "subtype": "bounding-box",
+                "required": ["west", "south", "east", "north"],
+                "properties": {
+                    "west": {
+                        "description": "West (lower left corner, coordinate axis 1).",
+                        "type": "number",
+                    },
+                    "south": {
+                        "description": "South (lower left corner, coordinate axis 2).",
+                        "type": "number",
+                    },
+                    "east": {
+                        "description": "East (upper right corner, coordinate axis 1).",
+                        "type": "number",
+                    },
+                    "north": {
+                        "description": "North (upper right corner, coordinate axis 2).",
+                        "type": "number",
+                    },
+                    "base": {
+                        "description": "Base (optional, lower left corner, coordinate axis 3).",
+                        "type": ["number", "null"],
+                        "default": "null",
+                    },
+                    "height": {
+                        "description": "Height (optional, upper right corner, coordinate axis 3).",
+                        "type": ["number", "null"],
+                        "default": "null",
+                    },
+                    "crs": {
+                        "description": "Coordinate reference system of the extent, specified as as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). Defaults to `4326` (EPSG code 4326) unless the client explicitly requests a different coordinate reference system.",
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "title": "EPSG Code",
+                                    "type": "integer",
+                                    "subtype": "epsg-code",
+                                    "examples": [7099],
+                                },
+                                {
+                                    "title": "WKT2",
+                                    "type": "string",
+                                    "subtype": "wkt2-definition",
+                                },
+                                {
+                                    "title": "PROJ definition",
+                                    "type": "string",
+                                    "subtype": "proj-definition",
+                                    "deprecated": "true",
+                                },
+                            ],
+                            "default": 4326,
+                        },
+                    },
+                },
+            },
+            {"title": "GeoJSON", "type": "object", "subtype": "geojson"},
+        ],
+        optional=False,
+    )
+    p_temporal = Parameter(
+        description="Limits the data to load from the collection to the specified left-closed temporal interval. Applies to all temporal dimensions if there are multiple of them. Left-closed temporal interval, i.e. an array with exactly two elements:\n\n1. The first element is the start of the date and/or time interval. The specified instance in time is **included** in the interval.\n2. The second element is the end of the date and/or time interval. The specified instance in time is **excluded** from the interval.\n\nThe specified temporal strings follow [RFC 3339](https://tools.ietf.org/html/rfc3339). Although [RFC 3339 prohibits the hour to be '24'](https://tools.ietf.org/html/rfc3339#section-5.7), **this process allows the value '24' for the hour** of an end time in order to make it possible that left-closed time intervals can fully cover the day.\n\nAlso supports open intervals by setting one of the boundaries to `null`, but never both.",
+        schema={
+            "type": "array",
+            "subtype": "temporal-interval",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": {
+                "anyOf": [
+                    {"type": "string", "format": "date-time", "subtype": "date-time"},
+                    {"type": "string", "format": "date", "subtype": "date"},
+                    {"type": "string", "subtype": "time"},
+                    {"type": "null"},
+                ]
+            },
+            "examples": [["2015-01-01", "2016-01-01"], ["12:00:00Z", "24:00:00Z"]],
+        },
+        optional=False,
+    )
 
     p_bands = Parameter(
         description="Only adds the specified bands into the data cube so that bands that don't match the list of band names are not available. Applies to all dimensions of type `bands` if there are multiple of them.\n\nThe order of the specified array defines the order of the bands in the data cube.",
-        schema=[
-            {
-                "type": "array",
-                "items": {
-                    "type": "string",
-                    "subtype": "band-name"}}])
+        schema=[{"type": "array", "items": {"type": "string", "subtype": "band-name"}}],
+    )
     p_properties = Parameter(
         description="Limits the data by metadata properties to include only data in the data cube which all given expressions return `true` for (AND operation).\n\nSpecify key-value-pairs with the keys being the name of the metadata property, which can be retrieved with the openEO Data Discovery for Collections. The values must be expressions to be evaluated against the collection metadata, see the example.\n\n**Note:** Back-ends may not pass the actual value to the expressions, but pass a proprietary index or a placeholder so that they can use the expressions to query against another data source. So debugging on the callback parameter `value` may lead to unexpected results.",
         experimental=True,
@@ -174,36 +152,36 @@ def create_process_description():
                         {
                             "name": "value",
                             "description": "The property value to be checked against.",
-                            "schema": {
-                             "description": "Any data type."}}]}}])
+                            "schema": {"description": "Any data type."},
+                        }
+                    ],
+                },
+            }
+        ],
+    )
 
-    rv = ReturnValue(description="Processed EO data.",
-                     schema={"type": "object", "subtype": "raster-cube"})
+    rv = ReturnValue(
+        description="Processed EO data.",
+        schema={"type": "object", "subtype": "raster-cube"},
+    )
 
     # Example
-    arguments = {"id": "latlong_wgs84.modis_ndvi_global.strds.ndvi_16_5600m",
-                 "spatial_extent": {
-                     "west": 16.1,
-                     "east": 16.6,
-                     "north": 48.6,
-                     "south": 47.2
-                     },
-                 "temporal_extent": [
-                     "2018-01-01",
-                     "2019-01-01"
-                 ],
-                 }
+    arguments = {
+        "id": "latlong_wgs84.modis_ndvi_global.strds.ndvi_16_5600m",
+        "spatial_extent": {"west": 16.1, "east": 16.6, "north": 48.6, "south": 47.2},
+        "temporal_extent": ["2018-01-01", "2019-01-01"],
+    }
     node = ProcessGraphNode(process_id=PROCESS_NAME, arguments=arguments)
     graph = ProcessGraph(
         title="title",
         description="description",
-        process_graph={
-            "load_strds_collection": node})
+        process_graph={"load_strds_collection": node},
+    )
     examples = [
         ProcessExample(
-            title="Simple example",
-            description="Simple example",
-            process_graph=graph)]
+            title="Simple example", description="Simple example", process_graph=graph
+        )
+    ]
 
     pd = ProcessDescription(
         id=PROCESS_NAME,
@@ -215,9 +193,11 @@ def create_process_description():
             "spatial_extent": p_spatial,
             "temporal_extent": p_temporal,
             "bands": p_bands,
-            "properties": p_properties},
+            "properties": p_properties,
+        },
         returns=rv,
-        examples=examples)
+        examples=examples,
+    )
 
     return json.loads(pd.to_json())
 
@@ -225,11 +205,13 @@ def create_process_description():
 PROCESS_DESCRIPTION_DICT[PROCESS_NAME] = create_process_description()
 
 
-def create_process_chain_entry(input_object: DataObject,
-                               spatial_extent,
-                               temporal_extent,
-                               bands,
-                               output_object: DataObject):
+def create_process_chain_entry(
+    input_object: DataObject,
+    spatial_extent,
+    temporal_extent,
+    bands,
+    output_object: DataObject,
+):
     """Create a Actinia process description that r.info, v.info, or t.info.
 
     :param input_object: The input object name
@@ -243,51 +225,71 @@ def create_process_chain_entry(input_object: DataObject,
 
     pc = []
 
+    importer = None
     if input_object.is_raster():
-        importer = {"id": "r_info_%i" % rn, "module": "r.info", "inputs": [
-            {"param": "map", "value": input_object.grass_name()}, ],
-            "flags": "g"}
+        importer = {
+            "id": "r_info_%i" % rn,
+            "module": "r.info",
+            "inputs": [
+                {"param": "map", "value": input_object.grass_name()},
+            ],
+            "flags": "g",
+        }
 
     elif input_object.is_vector():
-        importer = {"id": "v_info_%i" % rn, "module": "v.info", "inputs": [
-            {"param": "map", "value": input_object.grass_name()}, ],
-            "flags": "g"}
+        importer = {
+            "id": "v_info_%i" % rn,
+            "module": "v.info",
+            "inputs": [
+                {"param": "map", "value": input_object.grass_name()},
+            ],
+            "flags": "g",
+        }
 
     elif input_object.is_strds():
-        importer = {"id": "t_info_%i" % rn, "module": "t.info", "inputs": [
-            {"param": "input", "value": input_object.grass_name()}, ],
-            "flags": "g"}
+        importer = {
+            "id": "t_info_%i" % rn,
+            "module": "t.info",
+            "inputs": [
+                {"param": "input", "value": input_object.grass_name()},
+            ],
+            "flags": "g",
+        }
 
     elif input_object.is_stac():
         instance_id = input_object.mapset
         collection_id = f"stac.{instance_id}.rastercube.{input_object.name}"
-        strds_name = (output_object.grass_name()).replace('@', '_')
+        strds_name = (output_object.grass_name()).replace("@", "_")
         # Define the import process of the STAC collection
         stac_input_importer = {
-                    "import_descr": {
-                        "source": collection_id,
-                        "type": "stac"
-                    },
-                    "param": "map",
-                    "value": strds_name
-                }
-        param_import = _get_stac_importer(stac_input_importer, spatial_extent,
-                                          temporal_extent, bands, rn)
+            "import_descr": {"source": collection_id, "type": "stac"},
+            "param": "map",
+            "value": strds_name,
+        }
+        param_import = _get_stac_importer(
+            stac_input_importer, spatial_extent, temporal_extent, bands, rn
+        )
         stac_importchain = {
-                "id": "importer_1",
-                "module": "importer",
-                "inputs": [param_import]
-            }
+            "id": "importer_1",
+            "module": "importer",
+            "inputs": [param_import],
+        }
 
         pc.append(stac_importchain)
 
-        importer = {"id": "t_info_%i" % rn, "module": "t.info", "inputs": [
-            {"param": "input", "value": strds_name}, ],
-            "flags": "g"}
+        importer = {
+            "id": "t_info_%i" % rn,
+            "module": "t.info",
+            "inputs": [
+                {"param": "input", "value": strds_name},
+            ],
+            "flags": "g",
+        }
     else:
         raise Exception("Unsupported datatype")
 
-    pc.append(importer)
+    if importer:
+        pc.append(importer)
 
     # TODO: spatial extent can also be a GeoJSON object
     if spatial_extent is not None:
@@ -305,81 +307,124 @@ def create_process_chain_entry(input_object: DataObject,
 
         if input_object.is_raster():
             region_bbox = {
-                "id": "g_region_bbox_%i" %
-                rn, "module": "g.region.bbox", "inputs": [
-                    {
-                        "param": "n", "value": str(north)}, {
-                        "param": "s", "value": str(south)}, {
-                        "param": "e", "value": str(east)}, {
-                        "param": "w", "value": str(west)}, {
-                        "param": "crs", "value": str(crs)}, {
-                        "param": "raster", "value": input_object.grass_name()},
-                    ]}
+                "id": "g_region_bbox_%i" % rn,
+                "module": "g.region.bbox",
+                "inputs": [
+                    {"param": "n", "value": str(north)},
+                    {"param": "s", "value": str(south)},
+                    {"param": "e", "value": str(east)},
+                    {"param": "w", "value": str(west)},
+                    {"param": "crs", "value": str(crs)},
+                    {"param": "raster", "value": input_object.grass_name()},
+                ],
+            }
         elif input_object.is_strds() or input_object.is_stac():
             region_bbox = {
-                "id": "g_region_bbox_%i" %
-                rn, "module": "g.region.bbox", "inputs": [
-                    {
-                        "param": "n", "value": str(north)}, {
-                        "param": "s", "value": str(south)}, {
-                        "param": "e", "value": str(east)}, {
-                        "param": "w", "value": str(west)}, {
-                        "param": "crs", "value": str(crs)}, {
-                        "param": "strds", "value": input_object.grass_name()},
-                        ]
-                    }
+                "id": "g_region_bbox_%i" % rn,
+                "module": "g.region.bbox",
+                "inputs": [
+                    {"param": "n", "value": str(north)},
+                    {"param": "s", "value": str(south)},
+                    {"param": "e", "value": str(east)},
+                    {"param": "w", "value": str(west)},
+                    {"param": "crs", "value": str(crs)},
+                    {"param": "strds", "value": input_object.grass_name()},
+                ],
+            }
         else:
-            region_bbox = {"id": "g_region_bbox_%i" % rn,
-                           "module": "g.region.bbox",
-                           "inputs": [{"param": "n", "value": str(north)},
-                                      {"param": "s", "value": str(south)},
-                                      {"param": "e", "value": str(east)},
-                                      {"param": "w", "value": str(west)},
-                                      {"param": "crs", "value": str(crs)}, ]}
+            region_bbox = {
+                "id": "g_region_bbox_%i" % rn,
+                "module": "g.region.bbox",
+                "inputs": [
+                    {"param": "n", "value": str(north)},
+                    {"param": "s", "value": str(south)},
+                    {"param": "e", "value": str(east)},
+                    {"param": "w", "value": str(west)},
+                    {"param": "crs", "value": str(crs)},
+                ],
+            }
 
         pc.append(region_bbox)
 
-    if input_object.is_strds() and \
-       (temporal_extent is not None or bands is not None):
+        # local files to be imported with GDAL
+        # 1. use region as above
+        # 2. import with temporal filter
+        # 3. set region resolution from newly created strds
+        if input_object.is_local():
+            strds_name = (output_object.grass_name()).replace("@", "_")
+
+            # TODO: get root path from link in collection information ?
+
+            importer = {
+                "id": "t_in_eolab_%i" % rn,
+                "module": "t.in.eolab",
+                "inputs": [
+                    {"param": "collection", "value": input_object.name()},
+                    {"param": "start", "value": temporal_extent[0].split("T")[0]},
+                    {"param": "end", "value": temporal_extent[1].split("T")[0]},
+                    {"param": "bands", "value": ("', '").join(bands)},
+                    {"param": "output", "value": output_object.grass_name()},
+                ],
+            }
+
+            pc.append(importer)
+
+            region_bbox = {
+                "id": "g_region_bbox_%i" % rn,
+                "module": "g.region.bbox",
+                "inputs": [
+                    {"param": "n", "value": str(north)},
+                    {"param": "s", "value": str(south)},
+                    {"param": "e", "value": str(east)},
+                    {"param": "w", "value": str(west)},
+                    {"param": "crs", "value": str(crs)},
+                    {"param": "strds", "value": input_object.grass_name()},
+                ],
+            }
+
+            pc.append(region_bbox)
+
+    if input_object.is_strds() and (temporal_extent is not None or bands is not None):
         wherestring = ""
         if temporal_extent:
-            start_time = temporal_extent[0].replace('T', ' ')
+            start_time = temporal_extent[0].replace("T", " ")
             if len(temporal_extent) > 1:
-                end_time = temporal_extent[1].replace('T', ' ')
+                end_time = temporal_extent[1].replace("T", " ")
                 wherestring = "start_time >= '%(start)s' AND start_time < '%(end)s'" % {
-                                                "start": start_time, "end": end_time}
+                    "start": start_time,
+                    "end": end_time,
+                }
             # end_time can be null, use only start_time for filtering
             else:
                 wherestring = "start_time >= '%(start)s'" % {"start": start_time}
             if bands:
                 wherestring = wherestring + " AND "
         if bands:
-            wherestring = wherestring + \
-                "semantic_label in ('%(band_names)s')" % {"band_names": ("', '").join(bands)}
+            wherestring = wherestring + "semantic_label in ('%(band_names)s')" % {
+                "band_names": ("', '").join(bands)
+            }
 
         pc_strdsfilter = {
             "id": "t_rast_extract_%i" % rn,
             "module": "t.rast.extract",
-            "inputs": [{"param": "input",
-                        "value": input_object.grass_name()},
-                       {"param": "where",
-                        "value": wherestring},
-                       {"param": "output",
-                        "value": output_object.grass_name()},
-                       {"param": "expression",
-                        "value": "1.0 * %s" % input_object.name},
-                       {"param": "basename",
-                        "value": output_object.name},
-                       {"param": "suffix",
-                        "value": "num"}]}
+            "inputs": [
+                {"param": "input", "value": input_object.grass_name()},
+                {"param": "where", "value": wherestring},
+                {"param": "output", "value": output_object.grass_name()},
+                {"param": "expression", "value": "1.0 * %s" % input_object.name},
+                {"param": "basename", "value": output_object.name},
+                {"param": "suffix", "value": "num"},
+            ],
+        }
 
         pc.append(pc_strdsfilter)
 
     return pc
 
 
-def _get_stac_importer(stac_input_importer, spatial_extent=None,
-                       temporal_extent=None, bands=None, rn=None):
+def _get_stac_importer(
+    stac_input_importer, spatial_extent=None, temporal_extent=None, bands=None, rn=None
+):
     if spatial_extent is not None and temporal_extent is not None:
         # STAC Spatial Filtering
         north = spatial_extent["north"]
@@ -387,16 +432,12 @@ def _get_stac_importer(stac_input_importer, spatial_extent=None,
         west = spatial_extent["west"]
         east = spatial_extent["east"]
         extent = stac_input_importer["import_descr"]["extent"] = {}
-        extent["spatial"] = {
-            "bbox": [[north, west, south, east]]
-        }
+        extent["spatial"] = {"bbox": [[north, west, south, east]]}
 
         # STAC Temporal Filtering
-        start_time = temporal_extent[0].replace('T', ' ')
-        end_time = temporal_extent[1].replace('T', ' ')
-        extent["temporal"] = {
-            "interval": [[start_time, end_time]]
-        }
+        start_time = temporal_extent[0].replace("T", " ")
+        end_time = temporal_extent[1].replace("T", " ")
+        extent["temporal"] = {"interval": [[start_time, end_time]]}
 
         # TODO Check band format
         if bands is not None:
@@ -404,9 +445,7 @@ def _get_stac_importer(stac_input_importer, spatial_extent=None,
 
         return stac_input_importer
     else:
-        raise Exception(
-                "STAC collections require spatio-temporal filtering"
-        )
+        raise Exception("STAC collections require spatio-temporal filtering")
 
 
 def get_process_list(node: Node):
@@ -436,26 +475,30 @@ def get_process_list(node: Node):
     if "bands" in node.arguments:
         bands = node.arguments["bands"]
 
-    if input_object.is_strds() and \
-       (temporal_extent is not None or bands is not None):
+    if input_object.is_strds() and (temporal_extent is not None or bands is not None):
         output_object = DataObject(
             name=create_output_name(input_object.name, node),
-            datatype=input_object.datatype)
+            datatype=input_object.datatype,
+        )
     elif input_object.is_stac():
         output_object = DataObject(
             name=create_output_name(input_object.name, node),
-            datatype=input_object.datatype)
+            datatype=input_object.datatype,
+        )
+    elif input_object.is_local():
+        output_object = DataObject(
+            name=create_output_name(input_object.name, node),
+            datatype=input_object.datatype,
+        )
     else:
         output_object = input_object
 
     output_objects.append(output_object)
     node.add_output(output_object)
 
-    pc = create_process_chain_entry(input_object,
-                                    spatial_extent,
-                                    temporal_extent,
-                                    bands,
-                                    output_object)
+    pc = create_process_chain_entry(
+        input_object, spatial_extent, temporal_extent, bands, output_object
+    )
     process_list.extend(pc)
 
     return output_objects, process_list

--- a/src/openeo_grass_gis_driver/collections.py
+++ b/src/openeo_grass_gis_driver/collections.py
@@ -124,7 +124,7 @@ class Collections(Resource):
                     )
                     COLLECTIONS_LIST.append(ds)
 
-            # Additionally check for local collections registered in the openEO driver
+            # Additionally check for local collections registered here
             local_collections = get_local_collections()
 
             if ('collections' in local_collections and

--- a/src/openeo_grass_gis_driver/collections.py
+++ b/src/openeo_grass_gis_driver/collections.py
@@ -7,6 +7,8 @@ from openeo_grass_gis_driver.actinia_processing.actinia_interface import \
 from openeo_grass_gis_driver.actinia_processing.config import Config
 from openeo_grass_gis_driver.models.collection_schemas import \
      Collection, CollectionEntry
+from openeo_grass_gis_driver.local_collections import \
+     get_local_collections
 from openeo_grass_gis_driver.utils.logging import log
 
 
@@ -113,6 +115,34 @@ class Collections(Resource):
                         description = i['description']
                     except Exception:
                         description = "STAC collection registered in actinia"
+
+                    ds = CollectionEntry(
+                        id=i['id'],
+                        title=title,
+                        license=license,
+                        description=description
+                    )
+                    COLLECTIONS_LIST.append(ds)
+
+            # Additionally check for local collections registered in the openEO driver
+            local_collections = get_local_collections()
+
+            if ('collections' in local_collections and
+                    type(local_collections['collections']) is list):
+
+                for i in local_collections['collections']:
+                    try:
+                        title = i['title']
+                    except Exception:
+                        title = i['id']
+                    try:
+                        license = i['license']
+                    except Exception:
+                        license = "proprietary"
+                    try:
+                        description = i['description']
+                    except Exception:
+                        description = "local collection registered in the openEO backend"
 
                     ds = CollectionEntry(
                         id=i['id'],

--- a/src/openeo_grass_gis_driver/collections.py
+++ b/src/openeo_grass_gis_driver/collections.py
@@ -142,7 +142,7 @@ class Collections(Resource):
                     try:
                         description = i['description']
                     except Exception:
-                        description = "local collection registered in the openEO backend"
+                        description = "local collection registered here"
 
                     ds = CollectionEntry(
                         id=i['id'],

--- a/src/openeo_grass_gis_driver/local_collections.py
+++ b/src/openeo_grass_gis_driver/local_collections.py
@@ -2,10 +2,6 @@
 import os
 import json
 from pathlib import Path
-
-from openeo_grass_gis_driver.actinia_processing.actinia_interface import (
-    ActiniaInterface,
-)
 from openeo_grass_gis_driver.actinia_processing.base import (
     GrassDataType,
 )
@@ -59,13 +55,10 @@ def get_local_collection(name):
     return: collection
     """
 
-    iface = ActiniaInterface()
-    location, mapset, datatype, layer = iface.layer_def_to_components(name)
+    location, mapset, datatype, layer = name.split(".", 3)
 
     if location != "local":
         return None
-
-    del iface.PROCESS_LOCATION[location]
 
     local_collections_path = Config.LOCAL_COLLECTIONS
     jsonfile = os.path.join(local_collections_path, "%s.json" % layer)

--- a/src/openeo_grass_gis_driver/local_collections.py
+++ b/src/openeo_grass_gis_driver/local_collections.py
@@ -57,7 +57,7 @@ def get_local_collection(name):
     local_collections_path = Config.LOCAL_COLLECTIONS
     jsonfile = os.path.join(local_collections_path, "%s.json" % layer)
 
-    if not os.path_exists(jsonfile):
+    if not os.path.exists(jsonfile):
         return None
 
     with open(jsonfile) as f:

--- a/src/openeo_grass_gis_driver/local_collections.py
+++ b/src/openeo_grass_gis_driver/local_collections.py
@@ -11,7 +11,7 @@ from openeo_grass_gis_driver.actinia_processing.config import Config
 
 __license__ = "Apache License, Version 2.0"
 __author__ = "Markus Metz"
-__copyright__ = "Copyright 2018-2021, mundialis"
+__copyright__ = "Copyright 2018-2022, mundialis"
 __maintainer__ = "mundialis"
 
 

--- a/src/openeo_grass_gis_driver/local_collections.py
+++ b/src/openeo_grass_gis_driver/local_collections.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
-from flask_restful import Resource
-from flask import make_response, jsonify, request
+import os
+import json
+from pathlib import Path
 
 from openeo_grass_gis_driver.actinia_processing.actinia_interface import (
     ActiniaInterface,
 )
 from openeo_grass_gis_driver.actinia_processing.config import Config
-from openeo_grass_gis_driver.models.collection_schemas import (
-    Collection,
-    CollectionEntry,
-)
-from openeo_grass_gis_driver.utils.logging import log
 
 
 __license__ = "Apache License, Version 2.0"
@@ -53,13 +49,13 @@ def get_local_collection(name):
     """
 
     iface = ActiniaInterface()
-    location, mapset, datatype, layer = self.iface.layer_def_to_components(name)
+    location, mapset, datatype, layer = iface.layer_def_to_components(name)
 
     if location != "local":
         return None
 
     local_collections_path = Config.LOCAL_COLLECTIONS
-    jsonfile = os.path.join(local_collections_path, "%.json" % layer)
+    jsonfile = os.path.join(local_collections_path, "%s.json" % layer)
 
     if not os.path_exists(jsonfile):
         return None

--- a/src/openeo_grass_gis_driver/local_collections.py
+++ b/src/openeo_grass_gis_driver/local_collections.py
@@ -24,8 +24,9 @@ def get_local_collections():
 
     # get list of all json files at given path
     local_collections_path = Config.LOCAL_COLLECTIONS
+    local_collections_files = Path(local_collections_path).glob("**/*.json")
     jsonfiles = [
-        str(f) for f in Path(local_collections_path).glob("**/*.json") if f.is_file()
+        str(f) for f in local_collections_files if f.is_file()
     ]
 
     collections = {}

--- a/src/openeo_grass_gis_driver/local_collections.py
+++ b/src/openeo_grass_gis_driver/local_collections.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from flask_restful import Resource
+from flask import make_response, jsonify, request
+
+from openeo_grass_gis_driver.actinia_processing.actinia_interface import (
+    ActiniaInterface,
+)
+from openeo_grass_gis_driver.actinia_processing.config import Config
+from openeo_grass_gis_driver.models.collection_schemas import (
+    Collection,
+    CollectionEntry,
+)
+from openeo_grass_gis_driver.utils.logging import log
+
+
+__license__ = "Apache License, Version 2.0"
+__author__ = "Markus Metz"
+__copyright__ = "Copyright 2018-2021, mundialis"
+__maintainer__ = "mundialis"
+
+
+def get_local_collections():
+    """Get local collections: read all local json files at configured
+    path
+
+    return: collections
+    """
+
+    # get list of all json files at given path
+    local_collections_path = Config.LOCAL_COLLECTIONS
+    jsonfiles = [
+        str(f) for f in Path(local_collections_path).glob("**/*.json") if f.is_file()
+    ]
+
+    collections = {}
+    collections['collections'] = []
+
+    for j in jsonfiles:
+        with f as open(j):
+            collection = json.load(f)
+            name = j..split("/")[-1][:-5]
+            collection['id'] = "local.mapset.gdallocal.%s" % name
+            collections['collections'].append(collection)
+
+    return collections
+
+def get_local_collection(name):
+    """Get a local collection by name: read all local json files at configured
+    path
+
+    return: collection
+    """
+    
+    iface = ActiniaInterface()
+    location, mapset, datatype, layer = self.iface.layer_def_to_components(
+            name)
+
+    if location != "local":
+        return None
+    
+    local_collections_path = Config.LOCAL_COLLECTIONS
+    jsonfile = os.path.join(local_collections_path, "%.json" % layer)
+    
+    if not os.path_exists(jsonfile):
+        return None
+
+        with f as open(j):
+            collection = json.load(f)
+            name = j..split("/")[-1][:-5]
+            collection['id'] = "local.mapset.gdallocal.%s" % name
+
+    return collection

--- a/src/openeo_grass_gis_driver/local_collections.py
+++ b/src/openeo_grass_gis_driver/local_collections.py
@@ -33,16 +33,17 @@ def get_local_collections():
     ]
 
     collections = {}
-    collections['collections'] = []
+    collections["collections"] = []
 
     for j in jsonfiles:
-        with f as open(j):
+        with open(j) as f:
             collection = json.load(f)
-            name = j..split("/")[-1][:-5]
-            collection['id'] = "local.mapset.gdallocal.%s" % name
-            collections['collections'].append(collection)
+            name = j.split("/")[-1][:-5]
+            collection["id"] = "local.mapset.gdallocal.%s" % name
+            collections["collections"].append(collection)
 
     return collections
+
 
 def get_local_collection(name):
     """Get a local collection by name: read all local json files at configured
@@ -50,23 +51,22 @@ def get_local_collection(name):
 
     return: collection
     """
-    
+
     iface = ActiniaInterface()
-    location, mapset, datatype, layer = self.iface.layer_def_to_components(
-            name)
+    location, mapset, datatype, layer = self.iface.layer_def_to_components(name)
 
     if location != "local":
         return None
-    
+
     local_collections_path = Config.LOCAL_COLLECTIONS
     jsonfile = os.path.join(local_collections_path, "%.json" % layer)
-    
+
     if not os.path_exists(jsonfile):
         return None
 
-        with f as open(j):
+        with open(j) as f:
             collection = json.load(f)
-            name = j..split("/")[-1][:-5]
-            collection['id'] = "local.mapset.gdallocal.%s" % name
+            name = j.split("/")[-1][:-5]
+            collection["id"] = "local.mapset.gdallocal.%s" % name
 
     return collection

--- a/src/openeo_grass_gis_driver/local_collections.py
+++ b/src/openeo_grass_gis_driver/local_collections.py
@@ -64,9 +64,9 @@ def get_local_collection(name):
     if not os.path_exists(jsonfile):
         return None
 
-        with open(j) as f:
-            collection = json.load(f)
-            name = j.split("/")[-1][:-5]
-            collection["id"] = "local.mapset.gdallocal.%s" % name
+    with open(jsonfile) as f:
+        collection = json.load(f)
+        name = jsonfile.split("/")[-1][:-5]
+        collection["id"] = "local.mapset.gdallocal.%s" % name
 
     return collection


### PR DESCRIPTION
This PR adds support for local external collections where raster data are located in a local folder structure. These collections are described with json files following openEO syntax for collections. The json files must be located in `LOCAL_COLLECTIONS`, by default `$HOME/.openeo_local_collections`. Contents of this folder are read with the endpoints `/collections` and `collections/{collection_id}` and also when a collection is loaded with `load_collection`.